### PR TITLE
Move linux specific options to linux spec

### DIFF
--- a/config-linux.md
+++ b/config-linux.md
@@ -1,8 +1,7 @@
 # Linux
 
 ## Linux Namespaces
-
-```
+```json
     "namespaces": [
         "process",
         "network",
@@ -10,7 +9,7 @@
         "ipc",
         "uts",
         "user"
-    ],
+    ]
 ```
 
 Namespaces for the container are specified as an array of strings under the namespaces key. The list of constants that can be used is portable across operating systems. Here is a table mapping these names to native OS equivalent.
@@ -29,18 +28,34 @@ For Linux the mapping is
 
 * user -> user uids/gids on the host are mapped to different uids/gids in the container, so root in a container could be a non-root, unprivileged uid on the host
 
+### Access to devices
+```json
+   "devices": [
+        "null",
+        "random",
+        "full",
+        "tty",
+        "zero",
+        "urandom"
+    ]
+```
+
+Devices is an array specifying the list of devices from the host to make available in the container.
+
+The array contains names: for each name, the device /dev/<name> will be made available inside the container.
+
 ## Linux Control groups
 
 ## Linux Seccomp
 
 ## Linux Process Capabilities
 
-```
+```json
    "capabilities": [
         "AUDIT_WRITE",
         "KILL",
         "NET_BIND_SERVICE"
-    ],
+    ]
 ```
 
 capabilities is an array of Linux process capabilities. Valid values are the string after `CAP_` for capabilities defined in http://linux.die.net/man/7/capabilities
@@ -48,5 +63,4 @@ capabilities is an array of Linux process capabilities. Valid values are the str
 ## SELinux
 
 ## Apparmor
-
 

--- a/config.md
+++ b/config.md
@@ -2,7 +2,7 @@
 
 The container’s top-level directory MUST contain a configuration file called config.json. The configuration file MUST comply with the Open Container Configuration JSON Schema attached to this document. For now the schema is defined in [spec.go](https://github.com/opencontainers/runc/blob/master/spec.go) and [spec_linux.go](https://github.com/opencontainers/runc/blob/master/spec_linux.go), this will be moved to a JSON schema overtime.
 
-The configuration file contains metadata necessary to implement standard operations against the container. This includes processes to run, environment variables to inject, sandboxing features to use, etc.
+The configuration file contains metadata necessary to implement standard operations against the container. This includes process to run, environment variables to inject, sandboxing features to use, etc.
 
 Below is a detailed description of each field defined in the configuration format.
 
@@ -10,10 +10,9 @@ Below is a detailed description of each field defined in the configuration forma
 
 The `version` element specifies the version of the OCF specification which the container complies with. If the container is compliant with multiple versions, it SHOULD advertise the most recent known version to be supported.
 
-*Linux example*
-
-```
-    "version": "1",
+*Example*
+```json
+    "version": "1"
 ```
 
 ## File system configuration
@@ -24,18 +23,12 @@ The rootfs string element specifies the path to the root file system for the con
 
 The readonlyRootfs is an optional boolean element which defaults to false. If it is true, access to the root file system MUST be read-only for all processes running inside it, whether you want the root file system to be readonly or not for the processes running on it.
 
-*Example (Linux)*
-
-```
-    "rootfs": "rootfs",
-    "readonlyRootfs": true,
-```
-
-*Example (Windows)*
-
-```
-    "rootfs": "My Fancy Root FS",
-    "readonlyRootfs": true,
+*Example*
+```json
+    "root": {
+        "rootfs": "rootfs",
+        "readonlyRootfs": true
+    }
 ```
 
 Additional file systems can be declared as "mounts", declared by the array element mounts. The parameters are similar to the ones in Linux mount system call. [http://linux.die.net/man/2/mount](http://linux.die.net/man/2/mount)
@@ -50,7 +43,7 @@ options: in the fstab format [https://wiki.archlinux.org/index.php/Fstab](https:
 
 *Example (Linux)*
 
-```
+```json
     "mounts": [
         {
             "type": "proc",
@@ -80,16 +73,15 @@ options: in the fstab format [https://wiki.archlinux.org/index.php/Fstab](https:
 ```
 
 *Example (Windows)*
-```
+```json
     "mounts": [
         {
             "type": "ntfs",
-            "source": "\\?\Volume\{2eca078d-5cbc-43d3-aff8-7e8511f60d0e}\
-
-",
+            "source": "\\?\Volume\{2eca078d-5cbc-43d3-aff8-7e8511f60d0e}\",
             "destination": "C:\Users\crosbymichael\My Fancy Mount Point\",
             "options": ""
         }
+    ]
 ```
 
 See links for details about mountvol in Windows.
@@ -106,28 +98,20 @@ See links for details about mountvol in Windows.
 - Environment variables
 - Working directory
 
-*Example (Linux)*
-```
-    "processes": [
-        {
-            "tty": true,
-            "user": "daemon",
-            "args": [
-                "sh"
-            ],
-            "env": [
-                "PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin",
-                "TERM=xterm"
-            ],
-            "cwd": ""
-        }
-    ],
-```
-
-The processes to be created inside the container are specified in a processes array. They are started in order.
-
-```
-    "processes": [...]
+*Example*
+```json
+    "process": {
+        "terminal": true,
+        "user": "daemon",
+        "args": [
+            "sh"
+        ],
+        "env": [
+            "PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin",
+            "TERM=xterm"
+        ],
+        "cwd": ""
+    }
 ```
 
 The command to start a process is specified in an array of args. It will be run in the working directory specified in the string cwd.
@@ -138,66 +122,22 @@ Elements in the array are specified as Strings in the form "KEY=value"
 
 The user inside the container under which the process is running is specified under the user key.
 
-tty is a boolean that lets you specify whether you want a terminal attached to that process. tty cannot be set to true for more than one process in the array, else oc returns the error code THERE_CAN_BE_ONLY_ONE_TTY.
-
-*Example (Windows)*
-
-```
-    "processes": [
-        {
-            "tty": true,
-            "user": "Contoso\ScottGu",
-            "args": [
-                "cmd.exe"
-            ],
-            "env": [
-                "PATH=D:\Windows\Microsoft.NET\Framework\v4.0.30319;D:\Program Files (x86)\Git\bin",
-                "TERM=cygwin"
-            ],
-            "cwd": ""
-        }
-    ],
-```
+terminal is a boolean that lets you specify whether you want a terminal attached to that process. 
 
 hostname is a string specifying the hostname for that container as it is accessible to processes running in it.
 
 *Example*
-
+```json
+    "hostname": "mrsdalloway"
 ```
-    "hostname": "mrsdalloway",
-```
-
-### Resource Constraints
-
-The number of CPUs is specified as a positive decimal under the key cpus.
-
-The amount of memory allocated to this container is specified under the memory key, as an integer and is expressed in MB.
-
-If the cpu or memory requested are too high for the underlying environment capabilities, an error code NOT_ENOUGH_CPU or NOT_ENOUGH_MEM will be returned.
-
-
-### Access to devices
-
-```
-   "devices": [
-        "null",
-        "random",
-        "full",
-        "tty",
-        "zero",
-        "urandom"
-    ],
-```
-
-Devices is an array specifying the list of devices from the host to make available in the container.
-
-The array contains names: for each name, the device /dev/<name> will be made available inside the container.
 
 ## Machine-specific configuration
 
-```
-    "os": "linux",
-    "arch": "amd64",
+```json
+    "platform": {
+        "os": "linux",
+        "arch": "amd64"
+    }
 ```
 
 os specifies the operating system family this image must run on.


### PR DESCRIPTION
This moves some of the linux specific options like namespaces and
devices to the linux config document.  It also removes processes as an
array and replaces it with a single process.

It adds the "platform" struct for OS and Arch and updates many of the
examples to match the changes.  I also remove some of the redundant
windows examples on the portable spec document because they did not add
any extra value and many values were the same.

Signed-off-by: Michael Crosby <crosbymichael@gmail.com>