### PR TITLE
Add memory swappiness to linux spec

### DIFF
--- a/spec_linux.go
+++ b/spec_linux.go
@@ -106,6 +106,8 @@ type Memory struct {
 	Swap int64 `json:"swap"`
 	// Kernel memory limit (in bytes)
 	Kernel int64 `json:"kernel"`
+	// How aggressive the kernel will swap memory pages. Range from 0 to 100. Set -1 to use system default.
+	Swappiness int64 `json:"swappiness"`
 }
 
 type CPU struct {


### PR DESCRIPTION
I'm not able to start runc on ubuntu 14.04 with kernel version 3.13, and it's because runc fails to set swappiness.

This patch adds memory.swappiness to the spec, and then I'll send out patches to support setting swappiness in runc so we'll be able to leave swappiness as the system default value.