### PR TITLE
spec_linux.go: Rename IDMapping fields to follow syscall.SysProcIDMap

### DIFF
--- a/config-linux.md
+++ b/config-linux.md
@@ -123,16 +123,16 @@ rlimits allow setting resource limits. The type is from the values defined in [t
 ```
     "uidMappings": [
         {
-            "from"  : 1000,
-            "to"    : 0,
-            "count" : 10
+            "hostID": 1000,
+            "containerID": 0,
+            "size": 10
         }
     ],
     "gidMappings": [
         {
-            "from"  : 1000,
-            "to"    : 0,
-            "count" : 10
+            "hostID": 1000,
+            "containerID": 0,
+            "size": 10
         }
     ]
 ```

--- a/spec_linux.go
+++ b/spec_linux.go
@@ -52,12 +52,12 @@ type Namespace struct {
 
 // IDMapping specifies uid/gid mappings.
 type IDMapping struct {
-	// From is the uid/gid of the host user or group.
-	From int32 `json:"from"`
-	// To is the uid/gid of the container's user or group.
-	To int32 `json:"to"`
-	// Count is how many uid/gids to map after To.
-	Count int32 `json:"count"`
+	// HostID is the uid/gid of the host user or group.
+	HostID int32 `json:"hostID"`
+	// ContainerID is the uid/gid of the container's user or group.
+	ContainerID int32 `json:"containerID"`
+	// Size is the length of the range of IDs mapped between the two namespaces.
+	Size int32 `json:"size"`
 }
 
 // Rlimit type and restrictions.


### PR DESCRIPTION
'From' and 'To' are potentially ambiguous for a one-to-one map like
this, and there's already an established name convention in
SysProcIDMap [1].  This commit removes the mental overhead of two
separate naming schemes for the same information.  I'd like to drop
IDMapping entirely in favor of SysProcIDMap, but SysProcIDMap doesn't
give the JSON hints we need for (de)serializing.

[1]: https://golang.org/pkg/syscall/#SysProcIDMap