### PR TITLE
spec: linux: add support for the PIDs cgroup

### DIFF
--- a/runtime-config-linux.md
+++ b/runtime-config-linux.md
@@ -128,7 +128,7 @@ Next parameters can be specified:
 ## Control groups
 
 Also known as cgroups, they are used to restrict resource usage for a container and handle
-device access.  cgroups provide controls to restrict cpu, memory, IO, and network for
+device access.  cgroups provide controls to restrict cpu, memory, IO, pids and network for
 the container. For more information, see the [kernel cgroups documentation](https://www.kernel.org/doc/Documentation/cgroups/cgroups.txt).
 
 ## Sysctl

--- a/runtime_config_linux.go
+++ b/runtime_config_linux.go
@@ -126,6 +126,11 @@ type CPU struct {
 	Mems string `json:"mems"`
 }
 
+type Pids struct {
+	// Maximum number of PIDs. A value < 0 implies "no limit".
+	Limit int64 `json:"limit"`
+}
+
 // Network identification and priority configuration
 type Network struct {
 	// Set class identifier for container's network packets
@@ -142,6 +147,8 @@ type Resources struct {
 	Memory Memory `json:"memory"`
 	// CPU resource restriction configuration
 	CPU CPU `json:"cpu"`
+	// Task resource restriction configuration.
+	Pids Pids `json:"pids"`
 	// BlockIO restriction configuration
 	BlockIO BlockIO `json:"blockIO"`
 	// Hugetlb limit (in bytes)


### PR DESCRIPTION
Add support for the PIDs cgroup as a cgroup resource constraint in the
Linux container specification. Since PIDs are a real resource, we need
to support the ability to limit them.

The PIDs cgroup subsystem is available in Linux 4.3+.

Signed-off-by: Aleksa Sarai <cyphar@cyphar.com>

I realised while implementing opencontainers/runc#58 that if we want to
have PIDs support in the `config.json` we need to update the spec too.