### PR TITLE
specs: fix the description for the [ug]idMappings

### DIFF
--- a/config-linux.md
+++ b/config-linux.md
@@ -137,7 +137,7 @@ rlimits allow setting resource limits. The type is from the values defined in [t
     ]
 ```
 
-uid/gid mappings describe the user namespace mappings from the host to the container. *from* is the starting uid/gid on the host to be mapped to *to* which is the starting uid/gid in the container and *count* refers to the number of ids to be mapped. The Linux kernel has a limit of 5 such mappings that can be specified.
+uid/gid mappings describe the user namespace mappings from the host to the container. *hostID* is the starting uid/gid on the host to be mapped to *containerID* which is the starting uid/gid in the container and *size* refers to the number of ids to be mapped. The Linux kernel has a limit of 5 such mappings that can be specified.
 
 ## Rootfs Mount Propagation
 rootfsPropagation sets the rootfs's mount propagation. Its value is either slave, private, or shared. [The kernel doc](https://www.kernel.org/doc/Documentation/filesystems/sharedsubtree.txt) has more information about mount propagation.


### PR DESCRIPTION
The fields in the [ug]idMappings are changed, we should fix
the description correspondingly.

Signed-off-by: Lai Jiangshan <jiangshanlai@gmail.com>