### PR TITLE
specs: align the ascii graph

### DIFF
--- a/bundle.md
+++ b/bundle.md
@@ -21,7 +21,7 @@ One or more *content directories* may be adjacent to the configuration file. Thi
 ```
 /
 !
--- config.json
+--- config.json
 !
 --- rootfs
 !


### PR DESCRIPTION
The three files/directory are at the same level in the bundle directory,
they should be aligned.

Signed-off-by: Lai Jiangshan <jiangshanlai@gmail.com>