### PR TITLE
Add extra file descriptors to Process

### DIFF
--- a/config.md
+++ b/config.md
@@ -95,6 +95,7 @@ See links for details about [mountvol](http://ss64.com/nt/mountvol.html) and [Se
 * **cwd** (string, optional) is the working directory that will be set for the executable.
 * **env** (array of strings, optional) contains a list of variables that will be set in the process's environment prior to execution. Elements in the array are specified as Strings in the form "KEY=value". The left hand side must consist solely of letters, digits, and underscores `_` as outlined in [IEEE Std 1003.1-2001](http://pubs.opengroup.org/onlinepubs/009695399/basedefs/xbd_chap08.html).
 * **args** (string, required) executable to launch and any flags as an array. The executable is the first element and must be available at the given path inside of the rootfs. If the executable path is not an absolute path then the search $PATH is interpreted to find the executable.
+* **extraFiles** (array of int, optional) contains a list of open file descriptors that are passed to the process.
 
 The user for the process is a platform-specific structure that allows specific control over which user the process runs as.
 For Linux-based systems the user structure has the following fields:

--- a/spec.go
+++ b/spec.go
@@ -1,5 +1,9 @@
 package specs
 
+import (
+	"os"
+)
+
 // Spec is the base configuration for the container.  It specifies platform
 // independent configuration.
 type Spec struct {
@@ -53,6 +57,8 @@ type Process struct {
 	// Cwd is the current working directory for the process and must be
 	// relative to the container's root.
 	Cwd string `json:"cwd"`
+	// ExtraFiles specifies open file descriptors that should be passed to the process.
+	ExtraFiles []os.File `json:"extraFiles"`
 }
 
 // Root contains information about the container's root filesystem on the host.


### PR DESCRIPTION
It should be possible to pass file descriptors to the container process to support use cases
like systemd socket activation.

Signed-off-by: Mrunal Patel <mrunalp@gmail.com>