### PR TITLE
Change Device field order in spec_linux.go

### DIFF
--- a/spec_linux.go
+++ b/spec_linux.go
@@ -167,10 +167,10 @@ type Resources struct {
 }
 
 type Device struct {
-	// Device type, block, char, etc.
-	Type rune `json:"type"`
 	// Path to the device.
 	Path string `json:"path"`
+	// Device type, block, char, etc.
+	Type rune `json:"type"`
 	// Major is the device's major number.
 	Major int64 `json:"major"`
 	// Minor is the device's minor number.


### PR DESCRIPTION
Change Device field order in spec_linux.go, 'Path' should be top of the 'Type' field, according to the different of the config-linux.md, 'Path' field is the unique key.

Signed-off-by: LinZhinan(Zen Lin) <linzhinan@huawei.com>