### PR TITLE
README: Document BlueJeans for meetings

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,10 +73,8 @@ When in doubt, start on the [mailing-list](#mailing-list).
 ## Weekly Call
 
 The contributors and maintainers of the project have a weekly meeting Wednesdays at 10:00 AM PST.
-The link to the call will be posted on the mailing list each week along with set topics for discussion.
-Everyone is welcome to participate in the call, although there can only be speaking members on the Google Hangout.
-Participants who don't get a speaking slot can watch the live broadcast on [this YouTube channel][youtube] and post feedback and questions on [the IRC channel](#irc).
-Everyone is welcome to propose additional topics, suggest other agenda alterations, or request a speaking slot via the [mailing list](#mailing-list).
+Everyone is welcome to participate in the [BlueJeans call][BlueJeans].
+An initial agenda will be posted to the [mailing list](#mailing-list) earlier in the week, and everyone is welcome to propose additional topics or suggest other agenda alterations there.
 Minutes for the call will be posted to the [mailing list](#mailing-list) for those who are unable to join the call.
 
 ## Mailing List
@@ -148,4 +146,4 @@ using your real name (sorry, no pseudonyms or anonymous contributions.)
 
 You can add the sign off when creating the git commit via `git commit -s`.
 
-[youtube]: https://www.youtube.com/channel/UC1wmLdEYmwWcsFg7bt1s5nw
+[BlueJeans]: https://bluejeans.com/1771332256/


### PR DESCRIPTION
In #opencontainers after today's meeting, here's the source for the
change from Google Hangouts to BlueJeans:

12:01 < wking> Is the BlueJeans approach going to be our standard
  procedure?  If so, I can file a PR updating our weekly-meeting docs
  (which still talk about YouTube and Google Hangouts)
12:03 < mrunalp> wking: Yeah, I think so.
12:04 < wking> ok.  And it's just going to "push the BlueJeans link to
  IRC and the list before the meeting"?  Or does BlueJeans have stable
  channel URLs or similar?
12:05 < mrunalp> wking: The URL that we used today is stable.

And here's the source for archiving the minutes:

12:10 < wking> Will we still be posting mintes to the mailing-list, or
  are they now just on the wiki
  (https://github.com/opencontainers/specs/wiki)?
12:12 < mrunalp> wking: I am fine with either or both.
12:12 < wking> I'll go with both in the docs then
12:13 < mrunalp> sounds good

Signed-off-by: W. Trevor King <wking@tremily.us>