### PR TITLE
runtime: Document args[0] and the no-usable-args fallback

### DIFF
--- a/runtime.md
+++ b/runtime.md
@@ -75,22 +75,24 @@ If a hook returns a non-zero exit code, then an error is logged and the remainin
     "hooks" : {
         "prestart": [
             {
-                "path": "/usr/bin/fix-mounts",
-                "args": ["arg1", "arg2"],
+                "args": ["/usr/bin/fix-mounts", "arg1", "arg2"],
                 "env":  [ "key1=value1"]
             },
             {
-                "path": "/usr/bin/setup-network"
+                "path": "/usr/bin/setup-network",
+                "args": ["net.eth1", "start"],
             }
         ],
         "poststop": [
             {
-                "path": "/usr/sbin/cleanup.sh",
-                "args": ["-f"]
+                "args": ["/usr/sbin/cleanup.sh", "-f"]
             }
         ]
     }
 ```
 
-`path` is required for a hook.
-`args` and `env` are optional.
+`args` is passed to the executable, and includes the command as `args[0]` (which MUST be an absolute path).
+`path` is optional, but if set it MUST be an absolute path.
+When set, it takes precedence over `args[0]` when selecting for the executable, but it does not effect the arguments passed to that executable.
+For example, the `setup-network` script above will still have `net.eth1` as `args[0]`.
+`env` is optional.


### PR DESCRIPTION
Leaning on [Go's docs][1]:

> `Args` holds command line arguments, including the command as
> `Args[0]`. If the `Args` field is empty or `nil`, `Run` uses
> `{Path}`.

for the fallback wording.

This restores the ability to explicitly set `args[0]` independent of the
path, which [was requested in #34][2] and ack-ed by [Micheal][3] and
[Mrunal][4], but didn't match the examples that landed with #34.

This new wording matches the implementation that's currently in flight
as opencontainers/runc#160.  I also [raised this issue on the mailing
list][5], but didn't have any discussion there before we reached a
consensus in the runC PR.

[1]: http://golang.org/pkg/os/exec/#Cmd
[2]: https://github.com/opencontainers/specs/pull/34#issuecomment-126116173
[3]: https://github.com/opencontainers/specs/pull/34#issuecomment-127335834
[4]: https://github.com/opencontainers/specs/pull/34#issuecomment-127350235
[5]: https://groups.google.com/a/opencontainers.org/forum/#!topic/dev/luaaorsya10