### PR TITLE
Remove trailing whitespace

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ With Standard Containers we can put an end to that embarrassment, by making INDU
 Development happens on GitHub for the spec.
 Issues are used for bugs and actionable items and longer discussions can happen on the [mailing list](#mailing-list).
 
-The specification and code is licensed under the Apache 2.0 license found in the `LICENSE` file of this repository.  
+The specification and code is licensed under the Apache 2.0 license found in the `LICENSE` file of this repository.
 
 ## Discuss your design
 

--- a/runtime-config-linux.md
+++ b/runtime-config-linux.md
@@ -1,13 +1,11 @@
 ## Linux namespaces
 
-A namespace wraps a global system resource in an abstraction that makes it
-appear to the processes within the namespace that they have their own isolated
-instance of the global resource.  Changes to the global resource are visible to
-other processes that are members of the namespace, but are invisible to other
-processes. For more information, see [the man page](http://man7.org/linux/man-pages/man7/namespaces.7.html)
+A namespace wraps a global system resource in an abstraction that makes it appear to the processes within the namespace that they have their own isolated instance of the global resource.
+Changes to the global resource are visible to other processes that are members of the namespace, but are invisible to other processes.
+For more information, see [the man page](http://man7.org/linux/man-pages/man7/namespaces.7.html).
 
-Namespaces are specified in the spec as an array of entries. Each entry has a
-type field with possible values described below and an optional path element.
+Namespaces are specified in the spec as an array of entries.
+Each entry has a type field with possible values described below and an optional path element.
 If a path is specified, that particular file is used to join that type of namespace.
 
 ```json

--- a/runtime-config-linux.md
+++ b/runtime-config-linux.md
@@ -1,13 +1,13 @@
 ## Linux namespaces
 
-A namespace wraps a global system resource in an abstraction that makes it 
-appear to the processes within the namespace that they have their own isolated 
-instance of the global resource.  Changes to the global resource are visible to 
-other processes that are members of the namespace, but are invisible to other 
+A namespace wraps a global system resource in an abstraction that makes it
+appear to the processes within the namespace that they have their own isolated
+instance of the global resource.  Changes to the global resource are visible to
+other processes that are members of the namespace, but are invisible to other
 processes. For more information, see [the man page](http://man7.org/linux/man-pages/man7/namespaces.7.html)
 
-Namespaces are specified in the spec as an array of entries. Each entry has a 
-type field with possible values described below and an optional path element. 
+Namespaces are specified in the spec as an array of entries. Each entry has a
+type field with possible values described below and an optional path element.
 If a path is specified, that particular file is used to join that type of namespace.
 
 ```json


### PR DESCRIPTION
And adjust wrapping on touched lines to match the README's “Markdown
style” suggestions.

I also added a missing period after the namepaces(7) link.