### PR TITLE
JSON objects are easier to parse/manipulate

### DIFF
--- a/runtime-config.md
+++ b/runtime-config.md
@@ -5,7 +5,7 @@ Additional filesystems can be declared as "mounts", specified in the *mounts* ar
 * **type** (string, required) Linux, *filesystemtype* argument supported by the kernel are listed in */proc/filesystems* (e.g., "minix", "ext2", "ext3", "jfs", "xfs", "reiserfs", "msdos", "proc", "nfs", "iso9660"). Windows: ntfs
 * **source** (string, required) a device name, but can also be a directory name or a dummy. Windows, the volume name that is the target of the mount point. \\?\Volume\{GUID}\ (on Windows source is called target)
 * **destination** (string, required) where the source filesystem is mounted relative to the container rootfs.
-* **options** (string, optional) in the fstab format [https://wiki.archlinux.org/index.php/Fstab](https://wiki.archlinux.org/index.php/Fstab).
+* **options** (list of strings, optional) in the fstab format [https://wiki.archlinux.org/index.php/Fstab](https://wiki.archlinux.org/index.php/Fstab).
 
 *Example (Linux)*
 
@@ -15,25 +15,25 @@ Additional filesystems can be declared as "mounts", specified in the *mounts* ar
         "type": "proc",
         "source": "proc",
         "destination": "/proc",
-        "options": ""
+        "options": []
     },
     {
         "type": "tmpfs",
         "source": "tmpfs",
         "destination": "/dev",
-        "options": "nosuid,strictatime,mode=755,size=65536k"
+        "options": ["nosuid","strictatime","mode=755","size=65536k"]
     },
     {
         "type": "devpts",
         "source": "devpts",
         "destination": "/dev/pts",
-        "options": "nosuid,noexec,newinstance,ptmxmode=0666,mode=0620,gid=5"
+        "options": ["nosuid","noexec","newinstance","ptmxmode=0666","mode=0620","gid=5"]
     },
     {
         "type": "bind",
         "source": "/volumes/testing",
         "destination": "/data",
-        "options": "rbind,rw"
+        "options": ["rbind","rw"]
     }
 ]
 ```
@@ -46,11 +46,12 @@ Additional filesystems can be declared as "mounts", specified in the *mounts* ar
         "type": "ntfs",
         "source": "\\\\?\\Volume\\{2eca078d-5cbc-43d3-aff8-7e8511f60d0e}\\",
         "destination": "C:\\Users\\crosbymichael\\My Fancy Mount Point\\",
-        "options": ""
+        "options": []
     }
 ]
 ```
 
 See links for details about [mountvol](http://ss64.com/nt/mountvol.html) and [SetVolumeMountPoint](https://msdn.microsoft.com/en-us/library/windows/desktop/aa365561(v=vs.85).aspx) in Windows.
+
 
 

--- a/runtime_config.go
+++ b/runtime_config.go
@@ -32,5 +32,5 @@ type Mount struct {
 	// Destination is the path where the mount will be placed relative to the container's root.
 	Destination string `json:"destination"`
 	// Options are fstab style mount options.
-	Options string `json:"options"`
+	Options []string `json:"options"`
 }


### PR DESCRIPTION
Don't use strings when you can use dictionaries/objects. JSON objects are trivial to parse and manipulate, unlike strings. String parsing is the #1 cause of security bugs, so if it can be trivially avoided, then why not ;)