### PR TITLE
runtime_config_linux: Fix 'LinuxSpec' -> 'LinuxRuntimeSpec' in comment

### DIFF
--- a/runtime_config_linux.go
+++ b/runtime_config_linux.go
@@ -2,7 +2,7 @@ package specs
 
 import "os"
 
-// LinuxSpec is the full specification for linux containers.
+// LinuxRuntimeSpec is the full specification for linux containers.
 type LinuxRuntimeSpec struct {
 	RuntimeSpec
 	// Linux is platform specific configuration for linux based containers.


### PR DESCRIPTION
Fix a copy-paste error from 7232e4b1 (specs: introduce the concept of
a runtime.json, #88).