### PR TITLE
runtime-config: Remove blank lines from the end of files

### DIFF
--- a/runtime-config-linux.md
+++ b/runtime-config-linux.md
@@ -193,4 +193,3 @@ The actions and operators are strings that match the definitions in seccomp.h fr
        ]
    }
 ```
-

--- a/runtime-config.md
+++ b/runtime-config.md
@@ -52,6 +52,3 @@ Additional filesystems can be declared as "mounts", specified in the *mounts* ar
 ```
 
 See links for details about [mountvol](http://ss64.com/nt/mountvol.html) and [SetVolumeMountPoint](https://msdn.microsoft.com/en-us/library/windows/desktop/aa365561(v=vs.85).aspx) in Windows.
-
-
-


### PR DESCRIPTION
These snuck in with 7232e4b1 (specs: introduce the concept of a
runtime.json, 2015-07-30, #88) and 73bf1ba8 (JSON objects are easier
to parse/manipulate, 2015-08-27, #120).