### PR TITLE
config: Add example additionalGids

### DIFF
--- a/config.md
+++ b/config.md
@@ -56,7 +56,7 @@ For Linux-based systems the user structure has the following fields:
     "user": {
         "uid": 1,
         "gid": 1,
-        "additionalGids": []
+        "additionalGids": [5, 6]
     },
     "env": [
         "PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin",


### PR DESCRIPTION
The field is optional, but it's nice to have at least one example of
it in use.  The GIDs I've chosen are currently "tty" and "disk" on
Gentoo (1 is "bin"), which may be remotely reasonable choices, but the
values we're using don't really matter without an example filesystem
to provide context.

Signed-off-by: W. Trevor King <wking@tremily.us>