### PR TITLE
Add MAINTAINERS file

### DIFF
--- a/MAINTAINERS
+++ b/MAINTAINERS
@@ -1,0 +1,8 @@
+Michael Crosby <michael@docker.com> (@crosbymichael)
+Alexander Morozov <lk4d4@docker.com> (@LK4D4)
+Rohit Jnagal <jnagal@google.com> (@rjnagal)
+Victor Marmol <vmarmol@google.com> (@vmarmol)
+Mrunal Patel <mpatel@redhat.com> (@mrunalp)
+Vincent Batts <vbatts@redhat.com> (@vbatts)
+Daniel, Dao Quang Minh <dqminh89@gmail.com> (@dqminh)
+Brandon Philips <brandon.philips@coreos.com> (@philips)


### PR DESCRIPTION
This adds the maintainers file to the repo as the source of truth for OCI maintainers.  Please check your email addresses.

Signed-off-by: Michael Crosby <crosbymichael@gmail.com>