### PR TITLE
Return golint-compliant naming for mappings

### DIFF
--- a/config_linux.go
+++ b/config_linux.go
@@ -20,10 +20,10 @@ type Linux struct {
 // User specifies linux specific user and group information for the container's
 // main process.
 type User struct {
-	// Uid is the user id.
-	Uid int32 `json:"uid"`
-	// Gid is the group id.
-	Gid int32 `json:"gid"`
+	// UID is the user id.
+	UID int32 `json:"uid"`
+	// GID is the group id.
+	GID int32 `json:"gid"`
 	// AdditionalGids are additional group ids set for the container's process.
 	AdditionalGids []int32 `json:"additionalGids"`
 }

--- a/runtime_config_linux.go
+++ b/runtime_config_linux.go
@@ -10,10 +10,10 @@ type LinuxRuntimeSpec struct {
 }
 
 type LinuxRuntime struct {
-	// UidMapping specifies user mappings for supporting user namespaces on linux.
-	UidMappings []IDMapping `json:"uidMappings"`
-	// UidMapping specifies group mappings for supporting user namespaces on linux.
-	GidMappings []IDMapping `json:"gidMappings"`
+	// UIDMapping specifies user mappings for supporting user namespaces on linux.
+	UIDMappings []IDMapping `json:"uidMappings"`
+	// GIDMapping specifies group mappings for supporting user namespaces on linux.
+	GIDMappings []IDMapping `json:"gidMappings"`
 	// Rlimits specifies rlimit options to apply to the container's process.
 	Rlimits []Rlimit `json:"rlimits"`
 	// Sysctl are a set of key value pairs that are set for the container on start


### PR DESCRIPTION
It was lost in pull request about runtime config