### PR TITLE
add hypervisor volume example for runtime

### DIFF
--- a/runtime-config.md
+++ b/runtime-config.md
@@ -7,7 +7,7 @@ The parameters are similar to the ones in [the Linux mount system call](http://m
 Only [mounts from the portable config](config.md#mount-points) will be mounted.
 
 * **type** (string, required) Linux, *filesystemtype* argument supported by the kernel are listed in */proc/filesystems* (e.g., "minix", "ext2", "ext3", "jfs", "xfs", "reiserfs", "msdos", "proc", "nfs", "iso9660"). Windows: ntfs
-* **source** (string, required) a device name, but can also be a directory name or a dummy. Windows, the volume name that is the target of the mount point. \\?\Volume\{GUID}\ (on Windows source is called target)
+* **source** (string, required) a device name, but can also be a directory name or a dummy. Windows, the volume name that is the target of the mount point. \\?\Volume\{GUID}\ (on Windows source is called target). Hypervisor Runtime, source can be the volume type (e.g., "qcow2", "raw", "vdi", "rbd") and the path of volume.
 * **options** (list of strings, optional) in the fstab format [https://wiki.archlinux.org/index.php/Fstab](https://wiki.archlinux.org/index.php/Fstab).
 
 *Example (Linux)*
@@ -50,3 +50,15 @@ Only [mounts from the portable config](config.md#mount-points) will be mounted.
 ```
 
 See links for details about [mountvol](http://ss64.com/nt/mountvol.html) and [SetVolumeMountPoint](https://msdn.microsoft.com/en-us/library/windows/desktop/aa365561(v=vs.85).aspx) in Windows.
+
+*Example (Hypervisor)*
+
+```json
+"mounts": {
+    "data": {
+        "type": "ext3",
+        "source": "qcow2:/volumes/data.qcow2",
+        "options": ["rw"]
+    }
+}
+```


### PR DESCRIPTION
For hypervisor runtime, mount hypervisor volume for
container is useful.

Signed-off-by: Gao feng <omarapazanadi@gmail.com>