### PR TITLE
Change layout of mountpoints and mounts

### DIFF
--- a/config.go
+++ b/config.go
@@ -14,7 +14,7 @@ type Spec struct {
 	// Hostname is the container's host name.
 	Hostname string `json:"hostname"`
 	// Mounts profile configuration for adding mounts to the container's filesystem.
-	MountPoints []MountPoint `json:"mounts"`
+	Mounts []MountPoint `json:"mounts"`
 }
 
 // Process contains information to start a specific application inside the container.

--- a/config.md
+++ b/config.md
@@ -34,6 +34,37 @@ Each container has exactly one *root filesystem*, specified in the *root* object
 }
 ```
 
+## Mount Points
+
+You can add array of mount points inside container as `mounts`.
+Each record in this array must have configuration in [runtime config](runtime-config.md#mount-configuration).
+
+* **name** (string, required) Name of mount point. Used for config lookup.
+* **path** (string, required) Destination of mount point: path inside container.
+
+*Example*
+
+```json
+"mounts": [
+    {
+        "name": "proc",
+        "path": "/proc"
+    },
+    {
+        "name": "dev",
+        "path": "/dev"
+    },
+    {
+        "name": "devpts",
+        "path": "/dev/pts"
+    },
+    {
+        "name": "data",
+        "path": "/data"
+    }
+]
+```
+
 ## Process configuration
 
 * **terminal** (bool, optional) specifies whether you want a terminal attached to that process. Defaults to false.

--- a/runtime-config.md
+++ b/runtime-config.md
@@ -1,6 +1,10 @@
 ## Mount Configuration
 
-Additional filesystems can be declared as "mounts", specified in the *mounts* array. The parameters are similar to the ones in Linux mount system call. [http://linux.die.net/man/2/mount](http://linux.die.net/man/2/mount)
+Additional filesystems can be declared as "mounts", specified in the *mounts* object.
+Keys in this object are names of mount points from portable config.
+Values are objects with configuration of mount points.
+The parameters are similar to the ones in [the Linux mount system call](http://man7.org/linux/man-pages/man2/mount.2.html).
+Only [mounts from the portable config](config.md#mount-points) will be mounted.
 
 * **type** (string, required) Linux, *filesystemtype* argument supported by the kernel are listed in */proc/filesystems* (e.g., "minix", "ext2", "ext3", "jfs", "xfs", "reiserfs", "msdos", "proc", "nfs", "iso9660"). Windows: ntfs
 * **source** (string, required) a device name, but can also be a directory name or a dummy. Windows, the volume name that is the target of the mount point. \\?\Volume\{GUID}\ (on Windows source is called target)
@@ -10,45 +14,40 @@ Additional filesystems can be declared as "mounts", specified in the *mounts* ar
 *Example (Linux)*
 
 ```json
-"mounts": [
-    {
+"mounts": {
+    "proc": {
         "type": "proc",
         "source": "proc",
-        "destination": "/proc",
         "options": []
     },
-    {
+    "dev": {
         "type": "tmpfs",
         "source": "tmpfs",
-        "destination": "/dev",
         "options": ["nosuid","strictatime","mode=755","size=65536k"]
     },
-    {
+    "devpts": {
         "type": "devpts",
         "source": "devpts",
-        "destination": "/dev/pts",
         "options": ["nosuid","noexec","newinstance","ptmxmode=0666","mode=0620","gid=5"]
     },
-    {
+    "data": {
         "type": "bind",
         "source": "/volumes/testing",
-        "destination": "/data",
         "options": ["rbind","rw"]
     }
-]
+}
 ```
 
 *Example (Windows)*
 
 ```json
-"mounts": [
-    {
+"mounts": {
+    "myfancymountpoint": {
         "type": "ntfs",
         "source": "\\\\?\\Volume\\{2eca078d-5cbc-43d3-aff8-7e8511f60d0e}\\",
-        "destination": "C:\\Users\\crosbymichael\\My Fancy Mount Point\\",
         "options": []
     }
-]
+}
 ```
 
 See links for details about [mountvol](http://ss64.com/nt/mountvol.html) and [SetVolumeMountPoint](https://msdn.microsoft.com/en-us/library/windows/desktop/aa365561(v=vs.85).aspx) in Windows.

--- a/runtime_config.go
+++ b/runtime_config.go
@@ -1,8 +1,10 @@
 package specs
 
 type RuntimeSpec struct {
-	// Mounts profile configuration for adding mounts to the container's filesystem.
-	Mounts []Mount `json:"mounts"`
+	// Mounts is a mapping of names to mount configurations.
+	// Which mounts will be mounted and where should be chosen with MountPoints
+	// in Spec.
+	Mounts map[string]Mount `json:"mounts"`
 	// Hooks are the commands run at various lifecycle events of the container.
 	Hooks Hooks `json:"hooks"`
 }
@@ -29,8 +31,6 @@ type Mount struct {
 	// Source specifies the source path of the mount.  In the case of bind mounts on
 	// linux based systems this would be the file on the host.
 	Source string `json:"source"`
-	// Destination is the path where the mount will be placed relative to the container's root.
-	Destination string `json:"destination"`
 	// Options are fstab style mount options.
 	Options []string `json:"options"`
 }


### PR DESCRIPTION
Added info about MountPoints to config.md.

Filled after discuss in opencontainers/runc#242
I noticed that `MountPoints` still has json tag `mounts`, should I rename it to `mountPoints`?