### PR TITLE
CONTRIBUTING.md: Pull this out of the README

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,88 @@
+# Contributing
+
+Development happens on GitHub for the spec.
+Issues are used for bugs and actionable items and longer discussions can happen on the [mailing list][ml].
+
+The specification and code is licensed under the Apache 2.0 license found in the `LICENSE` file of this repository.
+
+## Discuss your design
+
+The project welcomes submissions, but please let everyone know what you are working on.
+
+Before undertaking a nontrivial change to this specification, send mail to the [mailing list][ml] to discuss what you plan to do.
+This gives everyone a chance to validate the design, helps prevent duplication of effort, and ensures that the idea fits.
+It also guarantees that the design is sound before code is written; a GitHub pull-request is not the place for high-level discussions.
+
+Typos and grammatical errors can go straight to a pull-request.
+When in doubt, start on the [mailing-list][ml].
+
+## Weekly Call
+
+The contributors and maintainers of the project have a weekly meeting Wednesdays at 10:00 AM PST.
+Everyone is welcome to participate in the [BlueJeans call][BlueJeans].
+An initial agenda will be posted to the [mailing list][ml] earlier in the week, and everyone is welcome to propose additional topics or suggest other agenda alterations there.
+Minutes for the call will be posted to the [mailing list][ml] for those who are unable to join the call.
+
+## Markdown style
+
+To keep consistency throughout the Markdown files in the Open Container spec all files should be formatted one sentence per line.
+This fixes two things: it makes diffing easier with git and it resolves fights about line wrapping length.
+For example, this paragraph will span three lines in the Markdown source.
+
+### Sign your work
+
+The sign-off is a simple line at the end of the explanation for the
+patch, which certifies that you wrote it or otherwise have the right to
+pass it on as an open-source patch.  The rules are pretty simple: if you
+can certify the below (from
+[developercertificate.org](http://developercertificate.org/)):
+
+```
+Developer Certificate of Origin
+Version 1.1
+
+Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
+660 York Street, Suite 102,
+San Francisco, CA 94110 USA
+
+Everyone is permitted to copy and distribute verbatim copies of this
+license document, but changing it is not allowed.
+
+
+Developer's Certificate of Origin 1.1
+
+By making a contribution to this project, I certify that:
+
+(a) The contribution was created in whole or in part by me and I
+    have the right to submit it under the open source license
+    indicated in the file; or
+
+(b) The contribution is based upon previous work that, to the best
+    of my knowledge, is covered under an appropriate open source
+    license and I have the right under that license to submit that
+    work with modifications, whether created in whole or in part
+    by me, under the same open source license (unless I am
+    permitted to submit under a different license), as indicated
+    in the file; or
+
+(c) The contribution was provided directly to me by some other
+    person who certified (a), (b) or (c) and I have not modified
+    it.
+
+(d) I understand and agree that this project and the contribution
+    are public and that a record of the contribution (including all
+    personal information I submit with it, including my sign-off) is
+    maintained indefinitely and may be redistributed consistent with
+    this project or the open source license(s) involved.
+```
+
+then you just add a line to every git commit message:
+
+    Signed-off-by: Joe Smith <joe@gmail.com>
+
+using your real name (sorry, no pseudonyms or anonymous contributions.)
+
+You can add the sign off when creating the git commit via `git commit -s`.
+
+[ml]: README.md#mailing-list
+[BlueJeans]: https://bluejeans.com/1771332256/

--- a/README.md
+++ b/README.md
@@ -52,30 +52,7 @@ There are 17 million shipping containers in existence, packed with every physica
 
 With Standard Containers we can put an end to that embarrassment, by making INDUSTRIAL-GRADE DELIVERY of software a reality.
 
-# Contributing
-
-Development happens on GitHub for the spec.
-Issues are used for bugs and actionable items and longer discussions can happen on the [mailing list](#mailing-list).
-
-The specification and code is licensed under the Apache 2.0 license found in the `LICENSE` file of this repository.
-
-## Discuss your design
-
-The project welcomes submissions, but please let everyone know what you are working on.
-
-Before undertaking a nontrivial change to this specification, send mail to the [mailing list](#mailing-list) to discuss what you plan to do.
-This gives everyone a chance to validate the design, helps prevent duplication of effort, and ensures that the idea fits.
-It also guarantees that the design is sound before code is written; a GitHub pull-request is not the place for high-level discussions.
-
-Typos and grammatical errors can go straight to a pull-request.
-When in doubt, start on the [mailing-list](#mailing-list).
-
-## Weekly Call
-
-The contributors and maintainers of the project have a weekly meeting Wednesdays at 10:00 AM PST.
-Everyone is welcome to participate in the [BlueJeans call][BlueJeans].
-An initial agenda will be posted to the [mailing list](#mailing-list) earlier in the week, and everyone is welcome to propose additional topics or suggest other agenda alterations there.
-Minutes for the call will be posted to the [mailing list](#mailing-list) for those who are unable to join the call.
+# Support
 
 ## Mailing List
 
@@ -85,65 +62,6 @@ You can subscribe and join the mailing list on [Google Groups](https://groups.go
 
 OCI discussion happens on #opencontainers on Freenode.
 
-## Markdown style
+## Contributing
 
-To keep consistency throughout the Markdown files in the Open Container spec all files should be formatted one sentence per line.
-This fixes two things: it makes diffing easier with git and it resolves fights about line wrapping length.
-For example, this paragraph will span three lines in the Markdown source.
-
-### Sign your work
-
-The sign-off is a simple line at the end of the explanation for the
-patch, which certifies that you wrote it or otherwise have the right to
-pass it on as an open-source patch.  The rules are pretty simple: if you
-can certify the below (from
-[developercertificate.org](http://developercertificate.org/)):
-
-```
-Developer Certificate of Origin
-Version 1.1
-
-Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
-660 York Street, Suite 102,
-San Francisco, CA 94110 USA
-
-Everyone is permitted to copy and distribute verbatim copies of this
-license document, but changing it is not allowed.
-
-
-Developer's Certificate of Origin 1.1
-
-By making a contribution to this project, I certify that:
-
-(a) The contribution was created in whole or in part by me and I
-    have the right to submit it under the open source license
-    indicated in the file; or
-
-(b) The contribution is based upon previous work that, to the best
-    of my knowledge, is covered under an appropriate open source
-    license and I have the right under that license to submit that
-    work with modifications, whether created in whole or in part
-    by me, under the same open source license (unless I am
-    permitted to submit under a different license), as indicated
-    in the file; or
-
-(c) The contribution was provided directly to me by some other
-    person who certified (a), (b) or (c) and I have not modified
-    it.
-
-(d) I understand and agree that this project and the contribution
-    are public and that a record of the contribution (including all
-    personal information I submit with it, including my sign-off) is
-    maintained indefinitely and may be redistributed consistent with
-    this project or the open source license(s) involved.
-```
-
-then you just add a line to every git commit message:
-
-    Signed-off-by: Joe Smith <joe@gmail.com>
-
-using your real name (sorry, no pseudonyms or anonymous contributions.)
-
-You can add the sign off when creating the git commit via `git commit -s`.
-
-[BlueJeans]: https://bluejeans.com/1771332256/
+There are notes on contributing to this project [here](CONTRIBUTING.md).


### PR DESCRIPTION
Pull-request submissions frequently miss the "Markdown style" section.
Separating contribution guidelines from README's general overview
isn't a huge change, but [GitHub's contributing hints][1] at least
increase the chance that folks read this over before submitting issues
or PRs.

I've left the list and IRC links in the README, since folks may want
to know about those even if they don't consider themselves to be
"contributors".

I've factored out the mailing-list links to use [reference-style
links][2], since that gives us only one place to update if we
rearrange things again in the future.  The shorter in-paragraph text
(`[mailing list][ml]` vs. the old `[mailing list](#mailing-list)`)
also makes it easier to read the paragraph source.

[1]: https://github.com/blog/1184-contributing-guidelines
[2]: http://daringfireball.net/projects/markdown/syntax#link