### PR TITLE
config: Reword the mount-point path description

### DIFF
--- a/config.md
+++ b/config.md
@@ -40,7 +40,7 @@ You can add array of mount points inside container as `mounts`.
 Each record in this array must have configuration in [runtime config](runtime-config.md#mount-configuration).
 
 * **name** (string, required) Name of mount point. Used for config lookup.
-* **path** (string, required) Destination of mount point: path inside container.
+* **path** (string, required) Mount destination in the container filesystem.
 
 *Example*
 


### PR DESCRIPTION
The colon-separated form works, but it took me a reread to understand
what it meant.

As I [suggested][1] for #136.

[1]: https://github.com/opencontainers/specs/pull/136/files#r38583332