### PR TITLE
runtime_config: Replace 'MountPoints in Spec' with 'Spec.Mounts'

### DIFF
--- a/runtime_config.go
+++ b/runtime_config.go
@@ -2,8 +2,7 @@ package specs
 
 type RuntimeSpec struct {
 	// Mounts is a mapping of names to mount configurations.
-	// Which mounts will be mounted and where should be chosen with MountPoints
-	// in Spec.
+	// Which mounts will be mounted and where should be chosen with Spec.Mounts.
 	Mounts map[string]Mount `json:"mounts"`
 	// Hooks are the commands run at various lifecycle events of the container.
 	Hooks Hooks `json:"hooks"`


### PR DESCRIPTION
I think Go's attribute syntax reads more clearly here, especially
since there is no 'Spec.MountPoints' after c18c283a (Change layout of
mountpoints and mounts, 2015-09-02, #136).

As I [suggested][1] for #136.

[1]: https://github.com/opencontainers/specs/pull/136/files#r38583510