### PR TITLE
config: Require the runtime to mount Spec.Mounts in order

### DIFF
--- a/config.md
+++ b/config.md
@@ -38,6 +38,7 @@ Each container has exactly one *root filesystem*, specified in the *root* object
 
 You can add array of mount points inside container as `mounts`.
 Each record in this array must have configuration in [runtime config](runtime-config.md#mount-configuration).
+The runtime MUST mount entries in the listed order.
 
 * **name** (string, required) Name of mount point. Used for config lookup.
 * **path** (string, required) Destination of mount point: path inside container.


### PR DESCRIPTION
If we don't specify this, some bundle-authors or runtime-implementers
might expect the runtime to intelligently order mounts to get the
"right" order.  But that's not possible because:

    $ mkdir -p a/b/c d/e/f h
    # mount --bind a/b h
    # mount --bind d a/b
    $ tree --charset=ascii h
    h
    `-- c

But in the other order:

    # umount a/b
    # umount h
    # mount --bind d a/b
    # mount --bind a/b h
    $ tree --charset=ascii h
    h
    `-- e
        `-- f

So there's no "right" order.  Allowing the bundle-author to specify
their intended order is both easy to implement and unambiguous.

Spun off from #136.