### PR TITLE
state: Shift the state tree to it's own set of files

### DIFF
--- a/config.go
+++ b/config.go
@@ -56,15 +56,3 @@ type MountPoint struct {
 	// Path specifies the path of the mount. The path and child directories MUST exist, a runtime MUST NOT create directories automatically to a mount point.
 	Path string `json:"path"`
 }
-
-// State holds information about the runtime state of the container.
-type State struct {
-	// Version is the version of the specification that is supported.
-	Version string `json:"version"`
-	// ID is the container ID
-	ID string `json:"id"`
-	// Pid is the process id for the container's main process.
-	Pid int `json:"pid"`
-	// Root is the path to the container's bundle directory.
-	Root string `json:"root"`
-}

--- a/runtime_config_linux.go
+++ b/runtime_config_linux.go
@@ -2,9 +2,6 @@ package specs
 
 import "os"
 
-// LinuxStateDirectory holds the container's state information
-const LinuxStateDirectory = "/run/oci/containers"
-
 // LinuxRuntimeSpec is the full specification for linux containers.
 type LinuxRuntimeSpec struct {
 	RuntimeSpec

--- a/state.go
+++ b/state.go
@@ -1,0 +1,13 @@
+package specs
+
+// State holds information about the runtime state of the container.
+type State struct {
+	// Version is the version of the specification that is supported.
+	Version string `json:"version"`
+	// ID is the container ID
+	ID string `json:"id"`
+	// Pid is the process id for the container's main process.
+	Pid int `json:"pid"`
+	// Root is the path to the container's bundle directory.
+	Root string `json:"root"`
+}

--- a/state_linux.go
+++ b/state_linux.go
@@ -1,0 +1,6 @@
+// +build linux
+
+package specs
+
+// LinuxStateDirectory holds the container's state information
+const LinuxStateDirectory = "/run/oci/containers"


### PR DESCRIPTION
@crosbymichael was adding these to existing Go files [to avoid having
a lot of files][1].  But 7232e4b (specs: introduce the concept of a
`runtime.json`, 2015-07-30, #88) split the runtime-configuration into
two file sets (one rooted in `config.go` for `config.json` and another
rooted in `runtime_config.go` for `runtime.json`).  In the face of a
two-set split for a single task (feeding the runtime while it
manipulates the container lifecycle), it seems odd to push the type
definition for a completely different task (sharing
container/application state with other tools) into an existing file
set.

Spun off from [here][2].  See also #126, which standardizes the JSON /
doc / Go naming pattern.

[1]: https://github.com/opencontainers/specs/pull/87#issuecomment-128137602
[2]: https://github.com/opencontainers/specs/pull/87#issuecomment-137200444