### PR TITLE
runtime: Add 'version' to the state.json example

### DIFF
--- a/runtime.md
+++ b/runtime.md
@@ -27,6 +27,7 @@ This is provided so that consumers can find the container's configuration and ro
 
 ```json
 {
+    "version": "0.2.0",
     "id": "oc-container",
     "pid": 4422,
     "root": "/containers/redis"


### PR DESCRIPTION
The version field was added while 180df9d (Add runtime state
configuration and structs, 2015-07-29, #87) was [in-flight][1], and it
missed getting documented in the example.

[1]: https://github.com/opencontainers/specs/pull/87#issuecomment-135117343