### PR TITLE
Specify UTF-8 for all our JSON

### DIFF
--- a/config.md
+++ b/config.md
@@ -1,6 +1,6 @@
 # Configuration file
 
-The container's top-level directory MUST contain a configuration file called `config.json`.
+The bundle's top-level directory MUST contain a configuration file called `config.json` with [UTF-8][] [JSON][].
 For now the canonical schema is defined in [spec.go](spec.go) and [spec_linux.go](spec_linux.go), but this will be moved to a formal JSON schema over time.
 
 The configuration file contains metadata necessary to implement standard operations against the container.
@@ -124,3 +124,6 @@ For Linux-based systems the user structure has the following fields:
 ```
 
 Interpretation of the platform section of the JSON file is used to find which platform-specific sections may be available in the document. For example, if `os` is set to `linux`, then a JSON object conforming to the [Linux-specific schema](config-linux.md) SHOULD be found at the key `linux` in the `config.json`.
+
+[UTF-8]: http://www.unicode.org/versions/Unicode8.0.0/ch03.pdf
+[JSON]: http://json.org/

--- a/runtime-config.md
+++ b/runtime-config.md
@@ -1,3 +1,8 @@
+# Host-specific container configuration
+
+The bundle's top-level directory MUST contain a configuration file called `runtime.json` with [UTF-8][] [JSON][].
+For now the canonical schema is defined in [`runtime_config.go`](runtime_config.go) and [runtime_config_linux.go](runtime_config.go), but this will be moved to a formal JSON schema over time.
+
 ## Mount Configuration
 
 Additional filesystems can be declared as "mounts", specified in the *mounts* object.
@@ -51,3 +56,6 @@ Only [mounts from the portable config](config.md#mount-points) will be mounted.
 ```
 
 See links for details about [mountvol](http://ss64.com/nt/mountvol.html) and [SetVolumeMountPoint](https://msdn.microsoft.com/en-us/library/windows/desktop/aa365561(v=vs.85).aspx) in Windows.
+
+[UTF-8]: http://www.unicode.org/versions/Unicode8.0.0/ch03.pdf
+[JSON]: http://json.org/

--- a/runtime.md
+++ b/runtime.md
@@ -3,7 +3,7 @@
 ## State
 
 The runtime state for a container is persisted on disk so that external tools can consume and act on this information.
-The runtime state is stored in a JSON encoded file.
+The runtime state is stored in a [UTF-8][] [JSON][] file.
 It is recommended that this file is stored in a temporary filesystem so that it can be removed on a system reboot.
 On Linux based systems the state information should be stored in `/run/oci/containers`.
 The directory structure for a container is `/run/oci/containers/<containerID>/state.json`.
@@ -86,3 +86,6 @@ If a hook returns a non-zero exit code, then an error is logged and the remainin
 ```
 
 `path` is required for a hook. `args` and `env` are optional.
+
+[UTF-8]: http://www.unicode.org/versions/Unicode8.0.0/ch03.pdf
+[JSON]: http://json.org/


### PR DESCRIPTION
I wish there was a cleaner reference for what UTF-8 was.  But linking
[Wikipedia][1] seems too glib, and I can't find a more targetted link
than just dropping folks into a Unicode chapter (which is what
[Wikipedia][1] does):

> The Unicode Standard, Version 6.0, §3.9 D92, §3.10 D95 (2011)

With the current v8.0 (2015-06-17), it's still §3.9 D92 and §3.10 D95.

To get a place to say this for the runtime.json docs, I used config.md
as a template for the top-level header and blurb.  The “Host-specific
container configuration” phrasing comes from bundle.md, which has:

> The `runtime.json` file contains settings that are host specific...

While I was touching the config.md lead-in, I fixed “container” →
“bundle”.

[1]: https://en.wikipedia.org/wiki/UTF-8