### PR TITLE
runtime: use opencontainer vs oci

### DIFF
--- a/runtime.md
+++ b/runtime.md
@@ -5,8 +5,8 @@
 The runtime state for a container is persisted on disk so that external tools can consume and act on this information.
 The runtime state is stored in a JSON encoded file.
 It is recommended that this file is stored in a temporary filesystem so that it can be removed on a system reboot.
-On Linux based systems the state information should be stored in `/run/oci/containers`.
-The directory structure for a container is `/run/oci/containers/<containerID>/state.json`.
+On Linux based systems the state information should be stored in `/run/opencontainer/containers`.
+The directory structure for a container is `/run/opencontainer/containers/<containerID>/state.json`.
 By providing a default location that container state is stored external applications can find all containers running on a system.
 
 * **version** (string) Version of the OCI specification used when creating the container.
@@ -23,7 +23,7 @@ The root directory to the bundle is provided in the state so that consumers can 
 
 ```json
 {
-    "id": "oci-container",
+    "id": "oc-container",
     "pid": 4422,
     "root": "/containers/redis"
 }

--- a/runtime_config_linux.go
+++ b/runtime_config_linux.go
@@ -3,7 +3,7 @@ package specs
 import "os"
 
 // LinuxStateDirectory holds the container's state information
-const LinuxStateDirectory = "/run/oci/containers"
+const LinuxStateDirectory = "/run/opencontainer/containers"
 
 // LinuxRuntimeSpec is the full specification for linux containers.
 type LinuxRuntimeSpec struct {


### PR DESCRIPTION
In an effort to be more discoverable and self-describing change out the
term "oci" for "opencontainer". We should consider using this as the
prefix for global namespaces going forward as oc has conflicts with
existing tools and oci is the name of the initiative not the specs.