### PR TITLE
Define constants for Linux Namespace names

### DIFF
--- a/runtime_config_linux.go
+++ b/runtime_config_linux.go
@@ -41,11 +41,23 @@ type LinuxRuntime struct {
 // Namespace is the configuration for a linux namespace.
 type Namespace struct {
 	// Type is the type of Linux namespace
-	Type string `json:"type"`
+	Type NamespaceType `json:"type"`
 	// Path is a path to an existing namespace persisted on disk that can be joined
 	// and is of the same type
 	Path string `json:"path"`
 }
+
+// NamespaceType is one of the linux namespaces
+type NamespaceType string
+
+const (
+	PIDNamespace     NamespaceType = "pid"
+	NetworkNamespace               = "network"
+	MountNamespace                 = "mount"
+	IPCNamespace                   = "ipc"
+	UTSNamespace                   = "uts"
+	UserNamespace                  = "user"
+)
 
 // IDMapping specifies UID/GID mappings
 type IDMapping struct {


### PR DESCRIPTION
Since the spec and the reference implementation are [currently out of sync on the names of the namespaces](https://github.com/opencontainers/runc/pull/247) (and the [spec and its own examples are out of sync too](https://github.com/opencontainers/specs/pull/149)) it seems wise to define these constants somewhere.

Note that this assumes the constants currently used by RunC are adopted for consistency (rather than vice versa) as discussed in https://github.com/opencontainers/runc/pull/247 and proposed in https://github.com/opencontainers/specs/pull/152. Happy to change the constants defined here to whichever of runc or the spec we decide is right, but I wanted to open the PR so we could discuss the concept.