### PR TITLE
Add hooks order explanation in `runtime.md`

### DIFF
--- a/runtime.md
+++ b/runtime.md
@@ -56,15 +56,13 @@ The pre-start hooks are called after the container process is spawned, but befor
 They are called after the container namespaces are created on Linux, so they provide an opportunity to customize the container.
 In Linux, for e.g., the network namespace could be configured in this hook.
 
-The hooks MUST be called in the listed order (`Prestart[0]` first, `Prestart[1]` second, …).
+The hooks MUST be called in the listed order (`prestart[0]` first, `prestart[1]` second, …).
 If a hook returns a non-zero exit code, then an error including the exit code and the stderr is returned to the caller and the container is torn down.
-
-
 
 ### Post-stop
 The post-stop hooks are called after the container process is stopped. Cleanup or debugging could be performed in such a hook.
 
-The hooks MUST be called in the listed order (`Poststop[0]` first, `Poststop[1]` second, …).
+The hooks MUST be called in the listed order (`poststop[0]` first, `poststop[1]` second, …).
 If a hook returns a non-zero exit code, then an error is logged and the remaining hooks are executed.
 
 *Example*

--- a/runtime.md
+++ b/runtime.md
@@ -56,10 +56,15 @@ The pre-start hooks are called after the container process is spawned, but befor
 They are called after the container namespaces are created on Linux, so they provide an opportunity to customize the container.
 In Linux, for e.g., the network namespace could be configured in this hook.
 
+The hooks MUST be called in the listed order (`Prestart[0]` first, `Prestart[1]` second, …).
 If a hook returns a non-zero exit code, then an error including the exit code and the stderr is returned to the caller and the container is torn down.
+
+
 
 ### Post-stop
 The post-stop hooks are called after the container process is stopped. Cleanup or debugging could be performed in such a hook.
+
+The hooks MUST be called in the listed order (`Poststop[0]` first, `Poststop[1]` second, …).
 If a hook returns a non-zero exit code, then an error is logged and the remaining hooks are executed.
 
 *Example*


### PR DESCRIPTION
I added a comment in:
https://github.com/opencontainers/specs/issues/20

Since one hook may rely on another(s) in the hooks list, 
add an explicit explanation will be helpful.

It will also be necessary if we convert the hooks to/from one prestart/poststop script.

The request is similar with wking's [#142](https://github.com/opencontainers/specs/pull/142)