### PR TITLE
Deduplicate the field of RootfsPropagation

### DIFF
--- a/config-linux.md
+++ b/config-linux.md
@@ -16,16 +16,6 @@ Valid values are the string after `CAP_` for capabilities defined in [the man pa
     ]
 ```
 
-## Rootfs Mount Propagation
-
-rootfsPropagation sets the rootfs's mount propagation.
-Its value is either slave, private, or shared.
-[The kernel doc](https://www.kernel.org/doc/Documentation/filesystems/sharedsubtree.txt) has more information about mount propagation.
-
-```json
-    "rootfsPropagation": "slave",
-```
-
 ## User namespace mappings
 
 ```json

--- a/config_linux.go
+++ b/config_linux.go
@@ -13,8 +13,6 @@ type LinuxSpec struct {
 type Linux struct {
 	// Capabilities are linux capabilities that are kept for the container.
 	Capabilities []string `json:"capabilities"`
-	// RootfsPropagation is the rootfs mount propagation mode for the container.
-	RootfsPropagation string `json:"rootfsPropagation"`
 }
 
 // User specifies linux specific user and group information for the container's

--- a/runtime-config-linux.md
+++ b/runtime-config-linux.md
@@ -194,3 +194,13 @@ The actions and operators are strings that match the definitions in seccomp.h fr
        ]
    }
 ```
+
+## Rootfs Mount Propagation
+
+rootfsPropagation sets the rootfs's mount propagation.
+Its value is either slave, private, or shared.
+[The kernel doc](https://www.kernel.org/doc/Documentation/filesystems/sharedsubtree.txt) has more information about mount propagation.
+
+```json
+    "rootfsPropagation": "slave",
+```


### PR DESCRIPTION
There are two RootfsPropagation fields, one is Linux.RootfsPropagation,
the other one is LinuxRuntime.RootfsPropagation. They are duplicated,
one of them should be removed.

The RootfsPropagation is definitely a runtime specific configuration,
so we remove the one of Linux.RootfsPropagation.

And the description of it is moved from config-linux.md to
runtime-config-linux.md.

Signed-off-by: Lai Jiangshan <jiangshanlai@gmail.com>