### PR TITLE
runtime-config: Remove 'destination' docs from mounts

### DIFF
--- a/runtime-config.md
+++ b/runtime-config.md
@@ -8,7 +8,6 @@ Only [mounts from the portable config](config.md#mount-points) will be mounted.
 
 * **type** (string, required) Linux, *filesystemtype* argument supported by the kernel are listed in */proc/filesystems* (e.g., "minix", "ext2", "ext3", "jfs", "xfs", "reiserfs", "msdos", "proc", "nfs", "iso9660"). Windows: ntfs
 * **source** (string, required) a device name, but can also be a directory name or a dummy. Windows, the volume name that is the target of the mount point. \\?\Volume\{GUID}\ (on Windows source is called target)
-* **destination** (string, required) where the source filesystem is mounted relative to the container rootfs.
 * **options** (list of strings, optional) in the fstab format [https://wiki.archlinux.org/index.php/Fstab](https://wiki.archlinux.org/index.php/Fstab).
 
 *Example (Linux)*


### PR DESCRIPTION
c18c283 (Change layout of mountpoints and mounts, 2015-09-02, #136)
removed the destination field from the Go type and examples, but
[forgot to remove it from the documentation][1].  Fix that with this
commit.

[1]: https://github.com/opencontainers/specs/issues/109#issuecomment-138531616