### PR TITLE
.tools: Fix redundant r.Pass check when 'fail == 0'

### DIFF
--- a/.tools/validate.go
+++ b/.tools/validate.go
@@ -74,20 +74,19 @@ func main() {
 		results = append(results, vr...)
 		if _, fail := vr.PassFail(); fail == 0 {
 			fmt.Println("PASS")
-			if *flVerbose {
-				for _, r := range vr {
-					if r.Pass {
-						fmt.Printf("  - %s\n", r.Msg)
-					}
-				}
-			}
 		} else {
 			fmt.Println("FAIL")
-			// default, only print out failed validations
-			for _, r := range vr {
-				if !r.Pass {
-					fmt.Printf("  - %s\n", r.Msg)
+		}
+		for _, r := range vr {
+			if *flVerbose {
+				if r.Pass {
+					fmt.Printf("ok")
+				} else {
+					fmt.Printf("not ok")
 				}
+				fmt.Printf(" %s\n", r.Msg)
+			} else if !r.Pass {
+				fmt.Printf("not ok %s\n", r.Msg)
 			}
 		}
 	}

--- a/.tools/validate.go
+++ b/.tools/validate.go
@@ -68,8 +68,13 @@ func main() {
 	}
 
 	results := ValidateResults{}
-	for _, commit := range c {
-		fmt.Printf(" * %s %s ... ", commit["abbreviated_commit"], commit["subject"])
+
+	if *flVerbose {
+		fmt.Println("TAP version 13")
+		fmt.Printf("1..%d\n", len(c)*len(DefaultRules))
+	}
+	for i, commit := range c {
+		fmt.Printf("# %s %s ... ", commit["abbreviated_commit"], commit["subject"])
 		vr := ValidateCommit(commit, DefaultRules)
 		results = append(results, vr...)
 		if _, fail := vr.PassFail(); fail == 0 {
@@ -77,16 +82,16 @@ func main() {
 		} else {
 			fmt.Println("FAIL")
 		}
-		for _, r := range vr {
+		for j, r := range vr {
 			if *flVerbose {
 				if r.Pass {
 					fmt.Printf("ok")
 				} else {
 					fmt.Printf("not ok")
 				}
-				fmt.Printf(" %s\n", r.Msg)
+				fmt.Printf(" %d - %s\n", i*len(DefaultRules)+j+1, r.Msg)
 			} else if !r.Pass {
-				fmt.Printf("not ok %s\n", r.Msg)
+				fmt.Printf("not ok - %s\n", r.Msg)
 			}
 		}
 	}


### PR DESCRIPTION
The previous version of this script would never print the success
messages, because when `fail == 0` was true, none of the messages
would satisfy `!r.Pass`.  This commit shifts the logic around to handle
the following cases:

a. If the verbose flag is set, print messages for all checks, using
   [TAP][1]'s "ok" and "not ok" to distinguish between per-check pass/fail.
b. If the verbose flag is not set, only print the failed messages (but
   still keep the "not ok" prefix).

[Spun off][2] from #170.

[1]: https://en.wikipedia.org/wiki/Test_Anything_Protocol
[2]: https://github.com/opencontainers/specs/pull/170/files#r39122874