### PR TITLE
proto: initial protobuf for config

### DIFF
--- a/proto/Makefile
+++ b/proto/Makefile
@@ -4,19 +4,28 @@ PROTO_FILES := $(wildcard *.proto)
 GO_FILES    := $(patsubst %.proto,%.pb.go,$(PROTO_FILES))
 C_FILES     := $(patsubst %.proto,%.pb-c.c,$(PROTO_FILES))
 C_HDR_FILES := $(patsubst %.proto,%.pb-c.h,$(PROTO_FILES))
+PY_FILES    := $(patsubst %.proto,%_pb2.py,$(PROTO_FILES))
 
 default: go
+
+all: go py c
 
 go: $(GO_FILES)
 
 %.pb.go: %.proto
-	protoc --go_out=$(DESTDIR) $<
+	protoc --go_out=$(DESTDIR) $^
 
 c: $(C_FILES)
 
 %.pb-c.c: %.proto
-	protoc-c --c_out=$(DESTDIR) $<
+	protoc-c --c_out=$(DESTDIR) $^
+
+py: $(PY_FILES)
+
+%_pb2.py: %.proto
+	protoc --python_out=$(DESTDIR) $^
+
 
 clean:
-	rm -rf *~ $(GO_FILES) $(C_FILES) $(C_HDR_FILES)
+	rm -rf *~ $(GO_FILES) $(C_FILES) $(C_HDR_FILES) $(PY_FILES)
 

--- a/proto/Makefile
+++ b/proto/Makefile
@@ -1,0 +1,22 @@
+
+DESTDIR     ?= .
+PROTO_FILES := $(wildcard *.proto)
+GO_FILES    := $(patsubst %.proto,%.pb.go,$(PROTO_FILES))
+C_FILES     := $(patsubst %.proto,%.pb-c.c,$(PROTO_FILES))
+C_HDR_FILES := $(patsubst %.proto,%.pb-c.h,$(PROTO_FILES))
+
+default: go
+
+go: $(GO_FILES)
+
+%.pb.go: %.proto
+	protoc --go_out=$(DESTDIR) $<
+
+c: $(C_FILES)
+
+%.pb-c.c: %.proto
+	protoc-c --c_out=$(DESTDIR) $<
+
+clean:
+	rm -rf *~ $(GO_FILES) $(C_FILES) $(C_HDR_FILES)
+

--- a/proto/config.proto
+++ b/proto/config.proto
@@ -7,7 +7,7 @@ message Spec {
 	// Version is the version of the specification that is supported.
 	optional string version = 1;
 	// Platform is the host information for OS and Arch.
-	optional Platform platform = 2; // [default=77];
+	optional Platform platform = 2;
 	// Process is the container's main process.
 	optional Process process = 3;
 	// Root is the root information for the container's filesystem.
@@ -69,7 +69,7 @@ enum PlatformType {
 message User {
 	// Type so that receivers of this message can `switch` for the fields
 	// expected
-	optional PlatformType type = 1 [default = LINUX];
+	optional PlatformType type = 1;
 
 	optional LinuxUser linux_type = 2;
 }

--- a/proto/config.proto
+++ b/proto/config.proto
@@ -72,17 +72,8 @@ message User {
 	// expected
 	optional PlatformType type = 1;
 
-	optional LinuxUser linux_type = 2;
-}
-
-// LinuxUser specifies linux specific user and group information for the
-// container's main process.
-message LinuxUser {
-	// Uid is the user id.
-	optional int32 uid = 1;
-	// Gid is the group id.
-	optional int32 gid = 2;
-	repeated int32 additional_gids = 3;
+	//optional LinuxUser linux_type = 2;
+	extensions 100 to 499;
 }
 
 // Root contains information about the container's root filesystem on the host.

--- a/proto/config.proto
+++ b/proto/config.proto
@@ -1,95 +1,105 @@
 //package oci.config.bundle;
 package oci;
 
-// Spec is the base configuration for the container.  It specifies platform
+// Spec is the base configuration for the container. It specifies platform
 // independent configuration.
 message Spec {
 	// Version is the version of the specification that is supported.
-  optional string Version = 1;
+	optional string version = 1;
 	// Platform is the host information for OS and Arch.
-  optional Platform Platform = 2; // [default=77];
+	optional Platform platform = 2; // [default=77];
 	// Process is the container's main process.
-  optional Process Process = 3;
+	optional Process process = 3;
 	// Root is the root information for the container's filesystem.
-  optional Root Root = 4;
+	optional Root root = 4;
 	// Hostname is the container's host name.
-  optional string Hostname = 5;
-	// Mounts profile configuration for adding mounts to the container's filesystem.
-  repeated MountPoint Mounts = 6;
+	optional string hostname = 5;
+	// Mounts profile configuration for adding mounts to the container's
+	// filesystem.
+	repeated MountPoint mounts = 6;
 }
 
 
 // LinuxSpec is the full specification for linux containers.
 message LinuxSpec {
-	optional Spec Spec = 1;
-	// LinuxConfig is platform specific configuration for linux based containers.
-	optional LinuxConfig LinuxConfig = 2;
+	optional Spec spec = 1;
+	// LinuxConfig is platform specific configuration for linux based
+	// containers.
+	optional LinuxConfig linux_config = 2;
 }
 
-// LinuxConfig contains platform specific configuration for linux based containers.
+// LinuxConfig contains platform specific configuration for linux based
+// containers.
 message LinuxConfig {
 	// Capabilities are linux capabilities that are kept for the container.
-	repeated string Capabilities = 1;
+	repeated string capabilities = 1;
 }
 
-// Platform specifies OS and arch information for the host system that the container
-// is created for.
+// Platform specifies OS and arch information for the host system that the
+// container is created for.
 message Platform {
 	// OS is the operating system.
-  optional string OS = 1;
+	optional string os = 1;
 	// Arch is the architecture
-  optional string Arch = 2;
+	optional string arch = 2;
 }
 
-// Process contains information to start a specific application inside the container.
+// Process contains information to start a specific application inside the
+// container.
 message Process {
 	// Terminal creates an interactive terminal for the container.
-	optional bool Terminal = 1;
+	optional bool terminal = 1;
 	// User specifies user information for the process.
-	optional User User = 2;
-	// Args specifies the binary and arguments for the application to execute.
-	repeated string Args = 3;
+	optional User user = 2;
+	// Args specifies the binary and arguments for the application to
+	// execute.
+	repeated string args = 3;
 	// Env populates the process environment for the process.
-	repeated string Env = 4;
+	repeated string env = 4;
 	// Cwd is the current working directory for the process and must be
 	// relative to the container's root.
-	optional string Cwd = 5;
+	optional string cwd = 5;
 }
 
 enum PlatformType {
-  LINUX = 1;
+	LINUX = 1;
 }
 
 // User specifies user information for the process.
 message User {
-	// Type so that receivers of this message can `switch` for the fields expected
-	optional PlatformType Type = 1 [default = LINUX];
+	// Type so that receivers of this message can `switch` for the fields
+	// expected
+	optional PlatformType type = 1 [default = LINUX];
 
-	optional LinuxUser LinuxUser = 2;
+	optional LinuxUser linux_type = 2;
 }
 
-// User specifies linux specific user and group information for the container's
-// main process.
+// LinuxUser specifies linux specific user and group information for the
+// container's main process.
 message LinuxUser {
-	// UID is the user id.
-	optional int32 UID = 1;
-	// GID is the group id.
-	optional int32 GID = 2;
-	repeated int32 AdditionalGids = 3;
+	// Uid is the user id.
+	optional int32 uid = 1;
+	// Gid is the group id.
+	optional int32 gid = 2;
+	repeated int32 additional_gids = 3;
 }
 
 // Root contains information about the container's root filesystem on the host.
 message Root {
 	// Path is the absolute path to the container's root filesystem.
-	optional string Path = 1;
-	// Readonly makes the root filesystem for the container readonly before the process is executed.
-	optional bool Readonly = 2;
+	optional string path = 1;
+	// Readonly makes the root filesystem for the container readonly before
+	// the process is executed.
+	optional bool readonly = 2;
 }
 
-// MountPoint describes a directory that may be fullfilled by a mount in the runtime.json.
+// MountPoint describes a directory that may be fullfilled by a mount in the
+// runtime.json.
 message MountPoint {
 	// Name is a unique descriptive identifier for this mount point.
-  optional string Name = 1;
-	// Path specifies the path of the mount. The path and child directories MUST exist, a runtime MUST NOT create directories automatically to a mount point.
-  optional string Path = 2;
+	optional string name = 1;
+	// Path specifies the path of the mount. The path and child directories
+	// MUST exist, a runtime MUST NOT create directories automatically to a
+	// mount point.
+	optional string path = 2;
 }

--- a/proto/config.proto
+++ b/proto/config.proto
@@ -1,18 +1,20 @@
 package oci;
-	
+
+//import "config_user.proto";
+
 // Spec is the base configuration for the container.  It specifies platform
 // independent configuration.
 message Spec {
 	// Version is the version of the specification that is supported.
-  required string Version = 1;
+  optional string Version = 1;
 	// Platform is the host information for OS and Arch.
-  required Platform Platform = 2; // [default=77];
+  optional Platform Platform = 2; // [default=77];
 	// Process is the container's main process.
-  required Process Process = 3;
+  optional Process Process = 3;
 	// Root is the root information for the container's filesystem.
-  required Root Root = 4;
+  optional Root Root = 4;
 	// Hostname is the container's host name.
-  required string Hostname = 5;
+  optional string Hostname = 5;
 	// Mounts profile configuration for adding mounts to the container's filesystem.
   repeated MountPoint Mounts = 6;
 }
@@ -21,39 +23,60 @@ message Spec {
 // is created for.
 message Platform {
 	// OS is the operating system.
-  required string OS = 1;
+  optional string OS = 1;
 	// Arch is the architecture
-  required string Arch = 2;
+  optional string Arch = 2;
 }
 
 // Process contains information to start a specific application inside the container.
 message Process {
 	// Terminal creates an interactive terminal for the container.
-	required bool Terminal = 1;
+	optional bool Terminal = 1;
 	// User specifies user information for the process.
-  // TODO(vbatts) figure out platform dependent types
-	//required User User = 2;
+	optional User User = 2;
 	// Args specifies the binary and arguments for the application to execute.
 	repeated string Args = 3;
 	// Env populates the process environment for the process.
 	repeated string Env = 4;
 	// Cwd is the current working directory for the process and must be
 	// relative to the container's root.
-	required string Cwd = 5;
+	optional string Cwd = 5;
+}
+
+enum PlatformType {
+  LINUX = 1;
+}
+
+// User specifies user information for the process.
+message User {
+  // Type so that receivers of this message can `switch` for the fields expected
+  optional PlatformType Type = 1 [default = LINUX];
+  // LinuxUserFields are to be used when Type is LINUX
+  optional linuxUserFields LinuxUserFields = 2;
+}
+
+// User specifies linux specific user and group information for the container's
+// main process.
+message linuxUserFields {
+	// UID is the user id.
+  optional int32 UID = 1;
+	// GID is the group id.
+  optional int32 GID = 2;
+  repeated int32 AdditionalGids = 3;
 }
 
 // Root contains information about the container's root filesystem on the host.
 message Root {
 	// Path is the absolute path to the container's root filesystem.
-	required string Path = 1;
+	optional string Path = 1;
 	// Readonly makes the root filesystem for the container readonly before the process is executed.
-	required bool Readonly = 2;
+	optional bool Readonly = 2;
 }
 
 // MountPoint describes a directory that may be fullfilled by a mount in the runtime.json.
 message MountPoint {
 	// Name is a unique descriptive identifier for this mount point.
-  required string Name = 1;
+  optional string Name = 1;
 	// Path specifies the path of the mount. The path and child directories MUST exist, a runtime MUST NOT create directories automatically to a mount point.
-  required string Path = 2;
+  optional string Path = 2;
 }

--- a/proto/config.proto
+++ b/proto/config.proto
@@ -1,6 +1,5 @@
+//package oci.config.bundle;
 package oci;
-
-//import "config_user.proto";
 
 // Spec is the base configuration for the container.  It specifies platform
 // independent configuration.
@@ -17,6 +16,20 @@ message Spec {
   optional string Hostname = 5;
 	// Mounts profile configuration for adding mounts to the container's filesystem.
   repeated MountPoint Mounts = 6;
+}
+
+
+// LinuxSpec is the full specification for linux containers.
+message LinuxSpec {
+	optional Spec Spec = 1;
+	// LinuxConfig is platform specific configuration for linux based containers.
+	optional LinuxConfig LinuxConfig = 2;
+}
+
+// LinuxConfig contains platform specific configuration for linux based containers.
+message LinuxConfig {
+	// Capabilities are linux capabilities that are kept for the container.
+	repeated string Capabilities = 1;
 }
 
 // Platform specifies OS and arch information for the host system that the container

--- a/proto/config.proto
+++ b/proto/config.proto
@@ -62,20 +62,20 @@ enum PlatformType {
 
 // User specifies user information for the process.
 message User {
-  // Type so that receivers of this message can `switch` for the fields expected
-  optional PlatformType Type = 1 [default = LINUX];
-  // LinuxUserFields are to be used when Type is LINUX
-  optional linuxUserFields LinuxUserFields = 2;
+	// Type so that receivers of this message can `switch` for the fields expected
+	optional PlatformType Type = 1 [default = LINUX];
+
+	optional LinuxUser LinuxUser = 2;
 }
 
 // User specifies linux specific user and group information for the container's
 // main process.
-message linuxUserFields {
+message LinuxUser {
 	// UID is the user id.
-  optional int32 UID = 1;
+	optional int32 UID = 1;
 	// GID is the group id.
-  optional int32 GID = 2;
-  repeated int32 AdditionalGids = 3;
+	optional int32 GID = 2;
+	repeated int32 AdditionalGids = 3;
 }
 
 // Root contains information about the container's root filesystem on the host.

--- a/proto/config.proto
+++ b/proto/config.proto
@@ -62,6 +62,7 @@ message Process {
 }
 
 enum PlatformType {
+	UNKNOWN = 0;
 	LINUX = 1;
 }
 

--- a/proto/config.proto
+++ b/proto/config.proto
@@ -1,0 +1,59 @@
+package oci;
+	
+// Spec is the base configuration for the container.  It specifies platform
+// independent configuration.
+message Spec {
+	// Version is the version of the specification that is supported.
+  required string Version = 1;
+	// Platform is the host information for OS and Arch.
+  required Platform Platform = 2; // [default=77];
+	// Process is the container's main process.
+  required Process Process = 3;
+	// Root is the root information for the container's filesystem.
+  required Root Root = 4;
+	// Hostname is the container's host name.
+  required string Hostname = 5;
+	// Mounts profile configuration for adding mounts to the container's filesystem.
+  repeated MountPoint Mounts = 6;
+}
+
+// Platform specifies OS and arch information for the host system that the container
+// is created for.
+message Platform {
+	// OS is the operating system.
+  required string OS = 1;
+	// Arch is the architecture
+  required string Arch = 2;
+}
+
+// Process contains information to start a specific application inside the container.
+message Process {
+	// Terminal creates an interactive terminal for the container.
+	required bool Terminal = 1;
+	// User specifies user information for the process.
+  // TODO(vbatts) figure out platform dependent types
+	//required User User = 2;
+	// Args specifies the binary and arguments for the application to execute.
+	repeated string Args = 3;
+	// Env populates the process environment for the process.
+	repeated string Env = 4;
+	// Cwd is the current working directory for the process and must be
+	// relative to the container's root.
+	required string Cwd = 5;
+}
+
+// Root contains information about the container's root filesystem on the host.
+message Root {
+	// Path is the absolute path to the container's root filesystem.
+	required string Path = 1;
+	// Readonly makes the root filesystem for the container readonly before the process is executed.
+	required bool Readonly = 2;
+}
+
+// MountPoint describes a directory that may be fullfilled by a mount in the runtime.json.
+message MountPoint {
+	// Name is a unique descriptive identifier for this mount point.
+  required string Name = 1;
+	// Path specifies the path of the mount. The path and child directories MUST exist, a runtime MUST NOT create directories automatically to a mount point.
+  required string Path = 2;
+}

--- a/proto/config_linux.proto
+++ b/proto/config_linux.proto
@@ -1,0 +1,14 @@
+package oci;
+
+import "config.proto";
+
+// LinuxUser specifies linux specific user and group information for the
+// container's main process.
+extend oci.User {
+	// Uid is the user id.
+	optional int32 uid = 101;
+	// Gid is the group id.
+	optional int32 gid = 102;
+	repeated int32 additional_gids = 103;
+}
+

--- a/proto/runtime_config.proto
+++ b/proto/runtime_config.proto
@@ -1,0 +1,54 @@
+//package oci.config.runtime;
+package oci;
+
+import "runtime_config_linux.proto";
+
+// RuntimeSpec is the generic runtime state information on a running container
+message RuntimeSpec {
+	// Mounts is a mapping of names to mount configurations.
+	// Which mounts will be mounted and where should be chosen with MountPoints
+	// in Spec.
+  repeated MountFieldEntry Mounts = 1;
+	// Hooks are the commands run at various lifecycle events of the container.
+	optional Hooks Hooks = 2;
+}
+
+// LinuxRuntimeSpec is the full specification for linux containers.
+message LinuxRuntimeSpec {
+	optional RuntimeSpec RuntimeSpec = 1;
+	// LinuxRuntime is platform specific configuration for linux based containers.
+	optional oci.LinuxRuntime Linux = 2;
+}
+
+// MountFieldEntry is more backwards compatible protobuf associative map (than map<string, Mount>)
+message MountFieldEntry {
+  required string key = 1;
+  required Mount value = 2;
+}
+
+// Mount specifies a mount for a container
+message Mount {
+	// Type specifies the mount kind.
+  optional string Type = 1;
+	// Source specifies the source path of the mount.  In the case of bind mounts on
+	// linux based systems this would be the file on the host.
+  optional string Source = 2;
+	// Options are fstab style mount options.
+  repeated string Options = 3;
+}
+
+// Hook specifies a command that is run at a particular event in the lifecycle of a container
+message Hook {
+	optional string Path = 1;
+	repeated string Args = 2;
+	repeated string Env = 3;
+}
+
+// Hooks for container setup and teardown
+message Hooks {
+	// Prestart is a list of hooks to be run before the container process is executed.
+	// On Linux, they are run after the container namespaces are created.
+  repeated Hook Prestart = 1;
+	// Poststop is a list of hooks to be run after the container process exits.
+  repeated Hook Poststop = 2;
+}

--- a/proto/runtime_config.proto
+++ b/proto/runtime_config.proto
@@ -8,7 +8,7 @@ message RuntimeSpec {
 	// Mounts is a mapping of names to mount configurations.
 	// Which mounts will be mounted and where should be chosen with MountPoints
 	// in Spec.
-  repeated MountFieldEntry Mounts = 1;
+	repeated MountFieldEntry Mounts = 1;
 	// Hooks are the commands run at various lifecycle events of the container.
 	optional Hooks Hooks = 2;
 }
@@ -22,19 +22,19 @@ message LinuxRuntimeSpec {
 
 // MountFieldEntry is more backwards compatible protobuf associative map (than map<string, Mount>)
 message MountFieldEntry {
-  required string key = 1;
-  required Mount value = 2;
+	required string key = 1;
+	required Mount value = 2;
 }
 
 // Mount specifies a mount for a container
 message Mount {
 	// Type specifies the mount kind.
-  optional string Type = 1;
-	// Source specifies the source path of the mount.  In the case of bind mounts on
+	optional string Type = 1;
+	// Source specifies the source path of the mount. In the case of bind mounts on
 	// linux based systems this would be the file on the host.
-  optional string Source = 2;
+	optional string Source = 2;
 	// Options are fstab style mount options.
-  repeated string Options = 3;
+	repeated string Options = 3;
 }
 
 // Hook specifies a command that is run at a particular event in the lifecycle of a container
@@ -48,7 +48,7 @@ message Hook {
 message Hooks {
 	// Prestart is a list of hooks to be run before the container process is executed.
 	// On Linux, they are run after the container namespaces are created.
-  repeated Hook Prestart = 1;
+	repeated Hook Prestart = 1;
 	// Poststop is a list of hooks to be run after the container process exits.
-  repeated Hook Poststop = 2;
+	repeated Hook Poststop = 2;
 }

--- a/proto/runtime_config.proto
+++ b/proto/runtime_config.proto
@@ -8,16 +8,16 @@ message RuntimeSpec {
 	// Mounts is a mapping of names to mount configurations.
 	// Which mounts will be mounted and where should be chosen with MountPoints
 	// in Spec.
-	repeated MountFieldEntry Mounts = 1;
+	repeated MountFieldEntry mounts = 1;
 	// Hooks are the commands run at various lifecycle events of the container.
-	optional Hooks Hooks = 2;
+	optional Hooks hooks = 2;
 }
 
 // LinuxRuntimeSpec is the full specification for linux containers.
 message LinuxRuntimeSpec {
-	optional RuntimeSpec RuntimeSpec = 1;
+	optional RuntimeSpec runtime_spec = 1;
 	// LinuxRuntime is platform specific configuration for linux based containers.
-	optional oci.LinuxRuntime Linux = 2;
+	optional oci.LinuxRuntime linux = 2;
 }
 
 // MountFieldEntry is more backwards compatible protobuf associative map (than map<string, Mount>)
@@ -29,26 +29,26 @@ message MountFieldEntry {
 // Mount specifies a mount for a container
 message Mount {
 	// Type specifies the mount kind.
-	optional string Type = 1;
+	optional string type = 1;
 	// Source specifies the source path of the mount. In the case of bind mounts on
 	// linux based systems this would be the file on the host.
-	optional string Source = 2;
+	optional string source = 2;
 	// Options are fstab style mount options.
-	repeated string Options = 3;
+	repeated string options = 3;
 }
 
 // Hook specifies a command that is run at a particular event in the lifecycle of a container
 message Hook {
-	optional string Path = 1;
-	repeated string Args = 2;
-	repeated string Env = 3;
+	optional string path = 1;
+	repeated string args = 2;
+	repeated string env = 3;
 }
 
 // Hooks for container setup and teardown
 message Hooks {
 	// Prestart is a list of hooks to be run before the container process is executed.
 	// On Linux, they are run after the container namespaces are created.
-	repeated Hook Prestart = 1;
+	repeated Hook prestart = 1;
 	// Poststop is a list of hooks to be run after the container process exits.
-	repeated Hook Poststop = 2;
+	repeated Hook poststop = 2;
 }

--- a/proto/runtime_config_linux.proto
+++ b/proto/runtime_config_linux.proto
@@ -3,58 +3,58 @@ package oci;
 // LinuxStateDirectory holds the container's state information
 message DefaultState {
 	// TODO(vbatts) not as elegant in some ways, but there is not a concept of const here
-	optional string Directory = 1 [default = "/run/opencontainer/containers"];
+	optional string directory = 1 [default = "/run/opencontainer/containers"];
 }
 
 // LinuxRuntime hosts the Linux-only runtime information
 message LinuxRuntime {
-	// UIDMapping specifies user mappings for supporting user namespaces on linux.
-	repeated IDMapping UIDMapping = 1;
-	// GIDMapping specifies group mappings for supporting user namespaces on linux.
-	repeated IDMapping GIDMapping = 2;
+	// UidMapping specifies user mappings for supporting user namespaces on linux.
+	repeated IDMapping uid_mapping = 1;
+	// GidMapping specifies group mappings for supporting user namespaces on linux.
+	repeated IDMapping gid_mapping = 2;
 	// Rlimits specifies rlimit options to apply to the container's process.
-	repeated Rlimit Rlimits = 3;
+	repeated Rlimit rlimits = 3;
 	// Sysctl are a set of key value pairs that are set for the container on start
-	repeated StringStringEntry Sysctl = 4;
+	repeated StringStringEntry sysctl = 4;
 	// Resources contain cgroup information for handling resource constraints
 	// for the container
-	optional Resources Resources = 5;
+	optional Resources resources = 5;
 	// CgroupsPath specifies the path to cgroups that are created and/or joined by the container.
 	// The path is expected to be relative to the cgroups mountpoint.
 	// If resources are specified, the cgroups at CgroupsPath will be updated based on resources.
-	optional string CgroupsPath = 6;
+	optional string cgroups_path = 6;
 	// Namespaces contains the namespaces that are created and/or joined by the container
-	repeated Namespace Namespaces = 7;
+	repeated Namespace namespaces = 7;
 	// Devices are a list of device nodes that are created and enabled for the container
-	repeated Device Devices = 8;
+	repeated Device devices = 8;
 	// ApparmorProfile specified the apparmor profile for the container.
-	optional string ApparmorProfile = 9;
+	optional string apparmor_profile = 9;
 	// SelinuxProcessLabel specifies the selinux context that the container process is run as.
-	optional string SelinuxProcessLabel = 10;
+	optional string selinux_process_label = 10;
 	// Seccomp specifies the seccomp security settings for the container.
-	optional Seccomp Seccomp = 11;
+	optional Seccomp seccomp = 11;
 	// RootfsPropagation is the rootfs mount propagation mode for the container
-	optional string RootfsPropagation = 12;
+	optional string rootfs_propagation = 12;
 }
 
 // IDMapping specifies UID/GID mappings
 message IDMapping {
 	// HostID is the UID/GID of the host user or group
-	optional int32 HostID = 1;
+	optional int32 host_id = 1;
 	// ContainerID is the UID/GID of the container's user or group
-	optional int32 ContainerID = 2;
+	optional int32 container_id = 2;
 	// Size is the length of the range of IDs mapped between the two namespaces
-	optional int32 Size = 3;
+	optional int32 size = 3;
 }
 
 // Rlimit type and restrictions
 message Rlimit {
 	// Type of the rlimit to set
-	optional string Type = 1;
+	optional string type = 1;
 	// Hard is the hard limit for the specified type
-	optional uint64 Hard = 2;
+	optional uint64 hard = 2;
 	// Soft is the soft limit for the specified type
-	optional uint64 Soft = 3;
+	optional uint64 soft = 3;
 }
 
 // StringStringEntry is more backwards compatible protobuf associative map (than map<string, Mount>)
@@ -66,31 +66,31 @@ message StringStringEntry {
 // Resources has container runtime resource constraints
 message Resources {
 	// DisableOOMKiller disables the OOM killer for out of memory conditions
-	optional bool DisableOOMKiller = 1;
+	optional bool disable_oom_killer = 1;
 	// Memory restriction configuration
-	optional Memory Memory = 2;
+	optional Memory memory = 2;
 	// CPU resource restriction configuration
-	optional CPU CPU = 3;
+	optional CPU cpu = 3;
 	// Task resource restriction configuration.
-	optional Pids Pids = 4;
+	optional Pids pids = 4;
 	// BlockIO restriction configuration
-	optional BlockIO BlockIO = 5;
+	optional BlockIO block_io = 5;
 	// Hugetlb limit (in bytes)
-	repeated HugepageLimit HugepageLimits = 6;
+	repeated HugepageLimit hugepage_limits = 6;
 	// Network restriction configuration
-	optional Network Network = 7;
+	optional Network network = 7;
 }
 
 // Memory for Linux cgroup 'memory' resource management
 message Memory {
 	// Memory limit (in bytes)
-	optional int64 Limit = 1;
+	optional int64 limit = 1;
 	// Memory reservation or soft_limit (in bytes)
-	optional int64 Reservation = 2;
+	optional int64 reservation = 2;
 	// Total memory usage (memory + swap); set `-1' to disable swap
-	optional int64 Swap = 3;
+	optional int64 swap = 3;
 	// Kernel memory limit (in bytes)
-	optional int64 Kernel = 4;
+	optional int64 kernel = 4;
 	// How aggressive the kernel will swap memory pages. Range from 0 to 100. Set -1 to use system default
 	optional int64 Swappiness = 5;
 }
@@ -98,116 +98,116 @@ message Memory {
 // CPU for Linux cgroup 'cpu' resource management
 message CPU {
 	// CPU shares (relative weight vs. other cgroups with cpu shares)
-	optional int64 Shares = 1;
+	optional int64 shares = 1;
 	// CPU hardcap limit (in usecs). Allowed cpu time in a given period
-	optional int64 Quota = 2;
+	optional int64 quota = 2;
 	// CPU period to be used for hardcapping (in usecs). 0 to use system default
-	optional int64 Period = 3;
+	optional int64 period = 3;
 	// How many time CPU will use in realtime scheduling (in usecs)
-	optional int64 RealtimeRuntime = 4;
+	optional int64 realtime_runtime = 4;
 	// CPU period to be used for realtime scheduling (in usecs)
-	optional int64 RealtimePeriod = 5;
+	optional int64 realtime_period = 5;
 	// CPU to use within the cpuset
-	optional string Cpus = 6;
+	optional string cpus = 6;
 	// MEM to use within the cpuset
-	optional string Mems = 7;
+	optional string mems = 7;
 }
 
 // Pids for Linux cgroup 'pids' resource management (Linux 4.3)
 message Pids {
 	// Maximum number of PIDs. A value < 0 implies "no limit".
-	optional int64 Limit = 1;
+	optional int64 limit = 1;
 }
 
 // BlockIO for Linux cgroup 'blockio' resource management
 message BlockIO {
 	// Specifies per cgroup weight, range is from 10 to 1000
-	optional int64 Weight = 1;
+	optional int64 weight = 1;
 	// Weight per cgroup per device, can override BlkioWeight
-	optional string WeightDevice = 2;
+	optional string weight_device = 2;
 	// IO read rate limit per cgroup per device, bytes per second
-	optional string ThrottleReadBpsDevice = 3;
+	optional string throttle_read_bps_device = 3;
 	// IO write rate limit per cgroup per divice, bytes per second
-	optional string ThrottleWriteBpsDevice = 4;
+	optional string throttle_write_bps_device = 4;
 	// IO read rate limit per cgroup per device, IO per second
-	optional string ThrottleReadIOpsDevice = 5;
+	optional string throttle_read_iops_device = 5;
 	// IO write rate limit per cgroup per device, IO per second
-	optional string ThrottleWriteIOpsDevice = 6;
+	optional string throttle_write_iops_device = 6;
 }
 
 // HugepageLimit structure corresponds to limiting kernel hugepages
 message HugepageLimit {
-	optional string Pagesize = 1;
-	optional int32 Limit = 2;
+	optional string pagesize = 1;
+	optional int32 limit = 2;
 }
 
 // Network identification and priority configuration
 message Network {
 	// Set class identifier for container's network packets
-	optional string ClassID = 1;
+	optional string class_id = 1;
 	// Set priority of network traffic for container
-	repeated InterfacePriority Priorities = 2;
+	repeated InterfacePriority priorities = 2;
 }
 
 // InterfacePriority for network interfaces
 message InterfacePriority {
 	// Name is the name of the network interface
-	optional string Name = 1;
+	optional string name = 1;
 	// Priority for the interface
-	optional int64 Priority = 2;
+	optional int64 priority = 2;
 }
 
 // Namespace is the configuration for a linux namespace
 message Namespace {
 	// Type is the type of Linux namespace
-	optional string Type = 1;
+	optional string type = 1;
 	// Path is a path to an existing namespace persisted on disk that can be joined
 	// and is of the same type
-	optional string Path = 2;
+	optional string path = 2;
 }
 
 // Device represents the information on a Linux special device file
 message Device {
 	// Path to the device.
-	optional string Path = 1;
+	optional string path = 1;
 	// Device type, block, char, etc.
 	// TODO(vbatts) ensure int32 is fine here, instead of golang's rune
-	optional int32 Type = 2;
+	optional int32 type = 2;
 	// Major is the device's major number.
-	optional int64 Major = 3;
+	optional int64 major = 3;
 	// Minor is the device's minor number.
-	optional int64 Minor = 4;
+	optional int64 minor = 4;
 	// Cgroup permissions format, rwm.
-	optional string Permissions = 5;
+	optional string permissions = 5;
 	// FileMode permission bits for the device.
 	// TODO(vbatts) os.FileMode is an octal uint32
-	optional uint32 FileMode = 6;
-	// UID of the device.
-	optional uint32 UID = 7;
+	optional uint32 file_mode = 6;
+	// Uid of the device.
+	optional uint32 uid = 7;
 	// Gid of the device.
-	optional uint32 GID = 8;
+	optional uint32 gid = 8;
 }
 
 // Seccomp represents syscall restrictions
 message Seccomp {
 	// TODO(vbatts) string instead of "Action" type
-	optional string DefaultAction = 1;
-	repeated Syscall Syscalls = 2;
+	optional string default_action = 1;
+	repeated Syscall syscalls = 2;
 }
 
 // Syscall is used to match a syscall in Seccomp
 message Syscall {
-	optional string Name = 1;
-	optional string Action = 2;
-	repeated Arg Args = 3;
+	optional string name = 1;
+	optional string action = 2;
+	repeated Arg args = 3;
 }
 
 // Arg used for matching specific syscall arguments in Seccomp
 message Arg {
-	optional uint32 Index = 1;
-	optional uint64 Value = 2;
-	optional uint64 ValueTwo = 3;
+	optional uint32 index = 1;
+	optional uint64 value = 2;
+	optional uint64 value_two = 3;
 	// Op is the operator string
-	optional string Op = 4;
+	optional string op = 4;
 }
 

--- a/proto/runtime_config_linux.proto
+++ b/proto/runtime_config_linux.proto
@@ -2,20 +2,20 @@ package oci;
 
 // LinuxStateDirectory holds the container's state information
 message DefaultState {
-  // TODO(vbatts) not as elegant in some ways, but there is not a concept of const here
-  optional string Directory = 1 [default =  "/run/opencontainer/containers"];
+	// TODO(vbatts) not as elegant in some ways, but there is not a concept of const here
+	optional string Directory = 1 [default = "/run/opencontainer/containers"];
 }
 
 // LinuxRuntime hosts the Linux-only runtime information
 message LinuxRuntime {
 	// UIDMapping specifies user mappings for supporting user namespaces on linux.
-  repeated IDMapping UIDMapping = 1;
+	repeated IDMapping UIDMapping = 1;
 	// GIDMapping specifies group mappings for supporting user namespaces on linux.
-  repeated IDMapping GIDMapping = 2;
+	repeated IDMapping GIDMapping = 2;
 	// Rlimits specifies rlimit options to apply to the container's process.
-  repeated Rlimit Rlimits = 3;
+	repeated Rlimit Rlimits = 3;
 	// Sysctl are a set of key value pairs that are set for the container on start
-  repeated StringStringEntry Sysctl = 4;
+	repeated StringStringEntry Sysctl = 4;
 	// Resources contain cgroup information for handling resource constraints
 	// for the container
 	optional Resources Resources = 5;
@@ -40,11 +40,11 @@ message LinuxRuntime {
 // IDMapping specifies UID/GID mappings
 message IDMapping {
 	// HostID is the UID/GID of the host user or group
-  optional int32 HostID = 1;
+	optional int32 HostID = 1;
 	// ContainerID is the UID/GID of the container's user or group
-  optional int32 ContainerID = 2;
+	optional int32 ContainerID = 2;
 	// Size is the length of the range of IDs mapped between the two namespaces
-  optional int32 Size = 3;
+	optional int32 Size = 3;
 }
 
 // Rlimit type and restrictions
@@ -59,8 +59,8 @@ message Rlimit {
 
 // StringStringEntry is more backwards compatible protobuf associative map (than map<string, Mount>)
 message StringStringEntry {
-  required string key = 1;
-  required string value = 2;
+	required string key = 1;
+	required string value = 2;
 }
 
 // Resources has container runtime resource constraints
@@ -171,7 +171,7 @@ message Device {
 	// Path to the device.
 	optional string Path = 1;
 	// Device type, block, char, etc.
-  // TODO(vbatts) ensure int32 is fine here, instead of golang's rune
+	// TODO(vbatts) ensure int32 is fine here, instead of golang's rune
 	optional int32 Type = 2;
 	// Major is the device's major number.
 	optional int64 Major = 3;
@@ -180,7 +180,7 @@ message Device {
 	// Cgroup permissions format, rwm.
 	optional string Permissions = 5;
 	// FileMode permission bits for the device.
-  // TODO(vbatts) os.FileMode is an octal uint32
+	// TODO(vbatts) os.FileMode is an octal uint32
 	optional uint32 FileMode = 6;
 	// UID of the device.
 	optional uint32 UID = 7;
@@ -190,7 +190,7 @@ message Device {
 
 // Seccomp represents syscall restrictions
 message Seccomp {
-  // TODO(vbatts) string instead of "Action" type
+	// TODO(vbatts) string instead of "Action" type
 	optional string DefaultAction = 1;
 	repeated Syscall Syscalls = 2;
 }
@@ -207,7 +207,7 @@ message Arg {
 	optional uint32 Index = 1;
 	optional uint64 Value = 2;
 	optional uint64 ValueTwo = 3;
-  // Op is the operator string
+	// Op is the operator string
 	optional string Op = 4;
 }
 

--- a/proto/runtime_config_linux.proto
+++ b/proto/runtime_config_linux.proto
@@ -1,0 +1,213 @@
+package oci;
+
+// LinuxStateDirectory holds the container's state information
+message DefaultState {
+  // TODO(vbatts) not as elegant in some ways, but there is not a concept of const here
+  optional string Directory = 1 [default =  "/run/opencontainer/containers"];
+}
+
+// LinuxRuntime hosts the Linux-only runtime information
+message LinuxRuntime {
+	// UIDMapping specifies user mappings for supporting user namespaces on linux.
+  repeated IDMapping UIDMapping = 1;
+	// GIDMapping specifies group mappings for supporting user namespaces on linux.
+  repeated IDMapping GIDMapping = 2;
+	// Rlimits specifies rlimit options to apply to the container's process.
+  repeated Rlimit Rlimits = 3;
+	// Sysctl are a set of key value pairs that are set for the container on start
+  repeated StringStringEntry Sysctl = 4;
+	// Resources contain cgroup information for handling resource constraints
+	// for the container
+	optional Resources Resources = 5;
+	// CgroupsPath specifies the path to cgroups that are created and/or joined by the container.
+	// The path is expected to be relative to the cgroups mountpoint.
+	// If resources are specified, the cgroups at CgroupsPath will be updated based on resources.
+	optional string CgroupsPath = 6;
+	// Namespaces contains the namespaces that are created and/or joined by the container
+	repeated Namespace Namespaces = 7;
+	// Devices are a list of device nodes that are created and enabled for the container
+	repeated Device Devices = 8;
+	// ApparmorProfile specified the apparmor profile for the container.
+	optional string ApparmorProfile = 9;
+	// SelinuxProcessLabel specifies the selinux context that the container process is run as.
+	optional string SelinuxProcessLabel = 10;
+	// Seccomp specifies the seccomp security settings for the container.
+	optional Seccomp Seccomp = 11;
+	// RootfsPropagation is the rootfs mount propagation mode for the container
+	optional string RootfsPropagation = 12;
+}
+
+// IDMapping specifies UID/GID mappings
+message IDMapping {
+	// HostID is the UID/GID of the host user or group
+  optional int32 HostID = 1;
+	// ContainerID is the UID/GID of the container's user or group
+  optional int32 ContainerID = 2;
+	// Size is the length of the range of IDs mapped between the two namespaces
+  optional int32 Size = 3;
+}
+
+// Rlimit type and restrictions
+message Rlimit {
+	// Type of the rlimit to set
+	optional string Type = 1;
+	// Hard is the hard limit for the specified type
+	optional uint64 Hard = 2;
+	// Soft is the soft limit for the specified type
+	optional uint64 Soft = 3;
+}
+
+// StringStringEntry is more backwards compatible protobuf associative map (than map<string, Mount>)
+message StringStringEntry {
+  required string key = 1;
+  required string value = 2;
+}
+
+// Resources has container runtime resource constraints
+message Resources {
+	// DisableOOMKiller disables the OOM killer for out of memory conditions
+	optional bool DisableOOMKiller = 1;
+	// Memory restriction configuration
+	optional Memory Memory = 2;
+	// CPU resource restriction configuration
+	optional CPU CPU = 3;
+	// Task resource restriction configuration.
+	optional Pids Pids = 4;
+	// BlockIO restriction configuration
+	optional BlockIO BlockIO = 5;
+	// Hugetlb limit (in bytes)
+	repeated HugepageLimit HugepageLimits = 6;
+	// Network restriction configuration
+	optional Network Network = 7;
+}
+
+// Memory for Linux cgroup 'memory' resource management
+message Memory {
+	// Memory limit (in bytes)
+	optional int64 Limit = 1;
+	// Memory reservation or soft_limit (in bytes)
+	optional int64 Reservation = 2;
+	// Total memory usage (memory + swap); set `-1' to disable swap
+	optional int64 Swap = 3;
+	// Kernel memory limit (in bytes)
+	optional int64 Kernel = 4;
+	// How aggressive the kernel will swap memory pages. Range from 0 to 100. Set -1 to use system default
+	optional int64 Swappiness = 5;
+}
+
+// CPU for Linux cgroup 'cpu' resource management
+message CPU {
+	// CPU shares (relative weight vs. other cgroups with cpu shares)
+	optional int64 Shares = 1;
+	// CPU hardcap limit (in usecs). Allowed cpu time in a given period
+	optional int64 Quota = 2;
+	// CPU period to be used for hardcapping (in usecs). 0 to use system default
+	optional int64 Period = 3;
+	// How many time CPU will use in realtime scheduling (in usecs)
+	optional int64 RealtimeRuntime = 4;
+	// CPU period to be used for realtime scheduling (in usecs)
+	optional int64 RealtimePeriod = 5;
+	// CPU to use within the cpuset
+	optional string Cpus = 6;
+	// MEM to use within the cpuset
+	optional string Mems = 7;
+}
+
+// Pids for Linux cgroup 'pids' resource management (Linux 4.3)
+message Pids {
+	// Maximum number of PIDs. A value < 0 implies "no limit".
+	optional int64 Limit = 1;
+}
+
+// BlockIO for Linux cgroup 'blockio' resource management
+message BlockIO {
+	// Specifies per cgroup weight, range is from 10 to 1000
+	optional int64 Weight = 1;
+	// Weight per cgroup per device, can override BlkioWeight
+	optional string WeightDevice = 2;
+	// IO read rate limit per cgroup per device, bytes per second
+	optional string ThrottleReadBpsDevice = 3;
+	// IO write rate limit per cgroup per divice, bytes per second
+	optional string ThrottleWriteBpsDevice = 4;
+	// IO read rate limit per cgroup per device, IO per second
+	optional string ThrottleReadIOpsDevice = 5;
+	// IO write rate limit per cgroup per device, IO per second
+	optional string ThrottleWriteIOpsDevice = 6;
+}
+
+// HugepageLimit structure corresponds to limiting kernel hugepages
+message HugepageLimit {
+	optional string Pagesize = 1;
+	optional int32 Limit = 2;
+}
+
+// Network identification and priority configuration
+message Network {
+	// Set class identifier for container's network packets
+	optional string ClassID = 1;
+	// Set priority of network traffic for container
+	repeated InterfacePriority Priorities = 2;
+}
+
+// InterfacePriority for network interfaces
+message InterfacePriority {
+	// Name is the name of the network interface
+	optional string Name = 1;
+	// Priority for the interface
+	optional int64 Priority = 2;
+}
+
+// Namespace is the configuration for a linux namespace
+message Namespace {
+	// Type is the type of Linux namespace
+	optional string Type = 1;
+	// Path is a path to an existing namespace persisted on disk that can be joined
+	// and is of the same type
+	optional string Path = 2;
+}
+
+// Device represents the information on a Linux special device file
+message Device {
+	// Path to the device.
+	optional string Path = 1;
+	// Device type, block, char, etc.
+  // TODO(vbatts) ensure int32 is fine here, instead of golang's rune
+	optional int32 Type = 2;
+	// Major is the device's major number.
+	optional int64 Major = 3;
+	// Minor is the device's minor number.
+	optional int64 Minor = 4;
+	// Cgroup permissions format, rwm.
+	optional string Permissions = 5;
+	// FileMode permission bits for the device.
+  // TODO(vbatts) os.FileMode is an octal uint32
+	optional uint32 FileMode = 6;
+	// UID of the device.
+	optional uint32 UID = 7;
+	// Gid of the device.
+	optional uint32 GID = 8;
+}
+
+// Seccomp represents syscall restrictions
+message Seccomp {
+  // TODO(vbatts) string instead of "Action" type
+	optional string DefaultAction = 1;
+	repeated Syscall Syscalls = 2;
+}
+
+// Syscall is used to match a syscall in Seccomp
+message Syscall {
+	optional string Name = 1;
+	optional string Action = 2;
+	repeated Arg Args = 3;
+}
+
+// Arg used for matching specific syscall arguments in Seccomp
+message Arg {
+	optional uint32 Index = 1;
+	optional uint64 Value = 2;
+	optional uint64 ValueTwo = 3;
+  // Op is the operator string
+	optional string Op = 4;
+}
+


### PR DESCRIPTION
To have a less source based, and more consumable example of structures,
this is an initial pass at protobuf structures for the structures in config.go

There is some exercise needed in platform specific structures.

For the sake of example, the Makefile defaults to outputing golang
source, but has a 'c' target (`make c`) for C source as well.

Signed-off-by: Vincent Batts <vbatts@hashbangbash.com>