### PR TITLE
.tools: Add per-commit Go checks (vet, fmt, and lint)

### DIFF
--- a/.tools/validate.go
+++ b/.tools/validate.go
@@ -74,20 +74,19 @@ func main() {
 		results = append(results, vr...)
 		if _, fail := vr.PassFail(); fail == 0 {
 			fmt.Println("PASS")
-			if *flVerbose {
-				for _, r := range vr {
-					if r.Pass {
-						fmt.Printf("  - %s\n", r.Msg)
-					}
-				}
-			}
 		} else {
 			fmt.Println("FAIL")
-			// default, only print out failed validations
-			for _, r := range vr {
-				if !r.Pass {
-					fmt.Printf("  - %s\n", r.Msg)
+		}
+		for _, r := range vr {
+			if *flVerbose {
+				if r.Pass {
+					fmt.Printf("ok")
+				} else {
+					fmt.Printf("not ok")
 				}
+				fmt.Printf(" %s\n", r.Msg)
+			} else if !r.Pass {
+				fmt.Printf("not ok %s\n", r.Msg)
 			}
 		}
 	}

--- a/.tools/validate.go
+++ b/.tools/validate.go
@@ -44,6 +44,22 @@ var DefaultRules = []ValidateRule{
 	},
 	// TODO add something for the cleanliness of the c.Subject
 	func(c CommitEntry) (vr ValidateResult) {
+		vr.CommitEntry = c
+		buf := bytes.NewBuffer([]byte{})
+		args := []string{"git", "show", "--check", c["commit"]}
+		vr.Msg = strings.Join(args, " ")
+		cmd := exec.Command(args[0], args[1:]...)
+		cmd.Stdout = buf
+		cmd.Stderr = os.Stderr
+		if err := cmd.Run(); err != nil {
+			vr.Pass = false
+			vr.Detail = string(buf.Bytes())
+			return vr
+		}
+		vr.Pass = true
+		return vr
+	},
+	func(c CommitEntry) (vr ValidateResult) {
 		return ExecTree(c, "go", "vet", "./...")
 	},
 	func(c CommitEntry) (vr ValidateResult) {

--- a/.tools/validate.go
+++ b/.tools/validate.go
@@ -47,6 +47,9 @@ var DefaultRules = []ValidateRule{
 		return ExecTree(c, "go", "vet", "./...")
 	},
 	func(c CommitEntry) (vr ValidateResult) {
+		return ExecTree(c, "go", "fmt", "./...")
+	},
+	func(c CommitEntry) (vr ValidateResult) {
 		vr = ExecTree(c, os.ExpandEnv("$HOME/gopath/bin/golint"), "./...")
 		if len(vr.Detail) > 0 {
 			vr.Pass = false

--- a/.tools/validate.go
+++ b/.tools/validate.go
@@ -68,8 +68,13 @@ func main() {
 	}
 
 	results := ValidateResults{}
-	for _, commit := range c {
-		fmt.Printf(" * %s %s ... ", commit["abbreviated_commit"], commit["subject"])
+
+	if *flVerbose {
+		fmt.Println("TAP version 13")
+		fmt.Printf("1..%d\n", len(c)*len(DefaultRules))
+	}
+	for i, commit := range c {
+		fmt.Printf("# %s %s ... ", commit["abbreviated_commit"], commit["subject"])
 		vr := ValidateCommit(commit, DefaultRules)
 		results = append(results, vr...)
 		if _, fail := vr.PassFail(); fail == 0 {
@@ -77,16 +82,16 @@ func main() {
 		} else {
 			fmt.Println("FAIL")
 		}
-		for _, r := range vr {
+		for j, r := range vr {
 			if *flVerbose {
 				if r.Pass {
 					fmt.Printf("ok")
 				} else {
 					fmt.Printf("not ok")
 				}
-				fmt.Printf(" %s\n", r.Msg)
+				fmt.Printf(" %d - %s\n", i*len(DefaultRules)+j+1, r.Msg)
 			} else if !r.Pass {
-				fmt.Printf("not ok %s\n", r.Msg)
+				fmt.Printf("not ok - %s\n", r.Msg)
 			}
 		}
 	}

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,12 +6,12 @@ go:
 sudo: false
 
 before_install:
-  - go get golang.org/x/tools/cmd/vet
   - go get github.com/golang/lint/golint
+  - go get golang.org/x/tools/cmd/vet
+  - go get gopkg.in/yaml.v2
 
 install: true
 
 script:
-  - $HOME/gopath/bin/golint ./...
   - go run .tools/validate.go -range ${TRAVIS_COMMIT_RANGE}
   

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,5 +13,6 @@ before_install:
 install: true
 
 script:
+  - echo ${TRAVIS_COMMIT_RANGE}
   - go run .tools/validate.go -range ${TRAVIS_COMMIT_RANGE}
   

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,6 +13,5 @@ before_install:
 install: true
 
 script:
-  - echo ${TRAVIS_COMMIT_RANGE}
-  - go run .tools/validate.go -range ${TRAVIS_COMMIT_RANGE}
-  
+  - echo "${TRAVIS_COMMIT_RANGE} -> ${TRAVIS_COMMIT_RANGE/.../..} (travis-ci/travis-ci#4596)"
+  - go run .tools/validate.go -range ${TRAVIS_COMMIT_RANGE/.../..}

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,6 @@ before_install:
 install: true
 
 script:
-  - go vet -x ./...
   - $HOME/gopath/bin/golint ./...
   - go run .tools/validate.go -range ${TRAVIS_COMMIT_RANGE}
   


### PR DESCRIPTION
Instead of just checking the tip, run the checks on each commit in the
series.  This makes sure we catch errors with earlier commits even if
they were fixed by subsequent commits.

There are some details about low-level choices in the commit messages
themselves, but nothing that seems generic enough to be worth copying
out to the PR level.

This PR is based on #174, because as the output gets more verbose
(e.g. YAML blocks for golint's stdout) you'll likely want to feed it
into a TAP harness for compaction.  The non-verbose output is still
pretty short, although there are now more tests which you can fail ;).

If the protobuf branch lands (#179), we can swap out the Go checkers
and swap in [protoc-gen-lint][1].  I'm not aware of any protobuf
equivalent to 'go fmt' though, which is unfortunate.

[1]: https://github.com/ckaznocha/protoc-gen-lint