### PR TITLE
Masked paths setting in the container

### DIFF
--- a/runtime-config-linux.md
+++ b/runtime-config-linux.md
@@ -250,6 +250,16 @@ The actions and operators are strings that match the definitions in seccomp.h fr
    }
 ```
 
+## Masked Paths
+
+Masked paths allow hiding paths in the container by bind mounting `/dev/null` over them to prevent access by the container process.
+
+```json
+   "maskedPaths": [
+       "/proc/kcore"
+   ]
+```
+
 ## Rootfs Mount Propagation
 
 rootfsPropagation sets the rootfs's mount propagation.

--- a/runtime_config_linux.go
+++ b/runtime_config_linux.go
@@ -41,6 +41,8 @@ type LinuxRuntime struct {
 	Seccomp Seccomp `json:"seccomp"`
 	// RootfsPropagation is the rootfs mount propagation mode for the container
 	RootfsPropagation string `json:"rootfsPropagation"`
+	// MaskedPaths is a list of paths that are hidden in the container.
+	MaskedPaths []string `json:"maskedPaths"`
 }
 
 // Namespace is the configuration for a linux namespace


### PR DESCRIPTION
This allows one to hide files such as `/proc/kcore` from the container process.

Signed-off-by: Mrunal Patel <mrunalp@gmail.com>