### PR TITLE
Add labels to the state

### DIFF
--- a/runtime.md
+++ b/runtime.md
@@ -23,6 +23,9 @@ This allows the hooks to perform cleanup and teardown logic after the runtime de
 * **`bundlePath`**: (string) is the absolute path to the container's bundle directory.
 This is provided so that consumers can find the container's configuration and root filesystem on the host.
 
+* **`annotations`**: (interface) holds runtime-specified information that is not structured by this specification.
+The runtime could store experimental information here before it's standardized in this specification.
+
 *Example*
 
 ```json

--- a/state.go
+++ b/state.go
@@ -13,4 +13,6 @@ type State struct {
 	Pid int `json:"pid"`
 	// BundlePath is the path to the container's bundle directory.
 	BundlePath string `json:"bundlePath"`
+	// Annotations holds runtime-specified information that is not structured by this specification.
+	Annotations interface{} `json:"annotations"`
 }


### PR DESCRIPTION
`Labels` is used to store some runtime specified informations,
these informations may be meaningless to other runtime, but it's
userful for the same runtime to operate this container.

Signed-off-by: Gao feng <omarapazanadi@gmail.com>
