### PR TITLE
introduce mount type 'null'

### DIFF
--- a/runtime-config.md
+++ b/runtime-config.md
@@ -6,7 +6,7 @@ Values are objects with configuration of mount points.
 The parameters are similar to the ones in [the Linux mount system call](http://man7.org/linux/man-pages/man2/mount.2.html).
 Only [mounts from the portable config](config.md#mount-points) will be mounted.
 
-* **type** (string, required) Linux, *filesystemtype* argument supported by the kernel are listed in */proc/filesystems* (e.g., "minix", "ext2", "ext3", "jfs", "xfs", "reiserfs", "msdos", "proc", "nfs", "iso9660"). Windows: ntfs
+* **type** (string, required) Linux, *filesystemtype* argument supported by the kernel are listed in */proc/filesystems* (e.g., "minix", "ext2", "ext3", "jfs", "xfs", "reiserfs", "msdos", "proc", "nfs", "iso9660"). Windows: ntfs. If type is "null", it means this mount entry should be ignored.
 * **source** (string, required) a device name, but can also be a directory name or a dummy. Windows, the volume name that is the target of the mount point. \\?\Volume\{GUID}\ (on Windows source is called target)
 * **options** (list of strings, optional) in the fstab format [https://wiki.archlinux.org/index.php/Fstab](https://wiki.archlinux.org/index.php/Fstab).
 
@@ -41,6 +41,11 @@ Only [mounts from the portable config](config.md#mount-points) will be mounted.
 
 ```json
 "mounts": {
+    "proc": {
+        "type": "null",
+        "source": "proc",
+        "options": []
+    },
     "myfancymountpoint": {
         "type": "ntfs",
         "source": "\\\\?\\Volume\\{2eca078d-5cbc-43d3-aff8-7e8511f60d0e}\\",


### PR DESCRIPTION
bundle.md said:
> The goal is that the bundle can be moved as a unit to another machine and run the same application if `runtime.json` is removed or reconfigured.

If we move the bundle from Linux to Windows. there is no linux filesystem on Windows,
and config.md said:
>Each record in this array must have configuration in [runtime config](runtime-config.md#mount-configuration).

So removing the `runtime.json` will not help to sucessfully run oci container with mounts configured.

This patch introduces a new mount type 'null', it means runtime should ignore this mount entry.
So we can change the os specified filesystem type to 'null' to make sure container can run sucessfully
on other os.

Signed-off-by: Gao feng <omarapazanadi@gmail.com>