### PR TITLE
Remove the unneeded build tag from the config_linux.go

### DIFF
--- a/config_linux.go
+++ b/config_linux.go
@@ -1,5 +1,3 @@
-// +build linux
-
 package specs
 
 // LinuxSpec is the full specification for linux containers.


### PR DESCRIPTION
config_linux.go already has the "_linux" for the go build,
so the build tag in the file is redundant.

Signed-off-by: Lai Jiangshan <jiangshanlai@gmail.com>