### PR TITLE
Fix typo in BlockIO struct comment

### DIFF
--- a/runtime_config_linux.go
+++ b/runtime_config_linux.go
@@ -104,7 +104,7 @@ type InterfacePriority struct {
 	Priority int64 `json:"priority"`
 }
 
-// BlockIO for Linux cgroup 'blockio' resource management
+// BlockIO for Linux cgroup 'blkio' resource management
 type BlockIO struct {
 	// Specifies per cgroup weight, range is from 10 to 1000
 	Weight int64 `json:"blkioWeight"`


### PR DESCRIPTION
it's `blkio` in kernel doc and under /sys/fs/cgroup
 
Signed-off-by: Antonio Murdaca <runcom@linux.com>