### PR TITLE
implementations: Add links to kunalkushwaha/octool and mrunalp/ocitools

### DIFF
--- a/implementations.md
+++ b/implementations.md
@@ -13,6 +13,7 @@ If you know of any associated projects that are not listed here, please file a p
 
 ## Bundle authoring
 
+* [kunalkushwaha/octool](https://github.com/kunalkushwaha/octool) - A config linter and validator.
 * [mrunalp/ocitools](https://github.com/mrunalp/ocitools) - A config generator.
 
 ## Testing

--- a/implementations.md
+++ b/implementations.md
@@ -11,6 +11,10 @@ If you know of any associated projects that are not listed here, please file a p
 
 * [hyperhq/runv](https://github.com/hyperhq/runv) - Hypervisor-based runtime for OCI
 
+## Bundle authoring
+
+* [mrunalp/ocitools](https://github.com/mrunalp/ocitools) - A config generator.
+
 ## Testing
 
 * [huawei-openlab/oct](https://github.com/huawei-openlab/oct) - Open Container Testing framework for OCI configuration and runtime


### PR DESCRIPTION
Details in the commit messages, but basically, if we've heard of an
OCI-related tool, I think we should be linking it from here ;).

@kunalkushwaha and @mrunalp, I've done my best at one-line summaries
based on your READMEs, but I'm happy to reroll these commits if you
prefer different phrasing (just tell me what to put in ;).