### PR TITLE
runtime-config-linux: Require libseccomp constants

### DIFF
--- a/runtime-config-linux.md
+++ b/runtime-config-linux.md
@@ -319,10 +319,9 @@ For more information about Apparmor, see [Apparmor documentation](https://wiki.u
 Seccomp provides application sandboxing mechanism in the Linux kernel.
 Seccomp configuration allows one to configure actions to take for matched syscalls and furthermore also allows matching on values passed as arguments to syscalls.
 For more information about Seccomp, see [Seccomp kernel documentation](https://www.kernel.org/doc/Documentation/prctl/seccomp_filter.txt)
-The actions, architectures, and operators are strings that match the definitions in seccomp.h from [libseccomp](https://github.com/seccomp/libseccomp) and are translated to corresponding values.
-A valid list of constants as of Libseccomp v2.2.3 is contained below.
+The set of valid constants MUST include the following (extracted from [libseccomp][]):
 
-Architecture Constants
+[Architecture Constants][libseccomp-architecture]:
 * `SCMP_ARCH_X86`
 * `SCMP_ARCH_X86_64`
 * `SCMP_ARCH_X32`
@@ -335,14 +334,14 @@ Architecture Constants
 * `SCMP_ARCH_MIPSEL64`
 * `SCMP_ARCH_MIPSEL64N32`
 
-Action Constants:
+[Action Constants][libseccomp-actions]:
 * `SCMP_ACT_KILL`
 * `SCMP_ACT_TRAP`
 * `SCMP_ACT_ERRNO`
 * `SCMP_ACT_TRACE`
 * `SCMP_ACT_ALLOW`
 
-Operator Constants:
+[Operator Constants][libseccomp-operators]:
 * `SCMP_CMP_NE`
 * `SCMP_CMP_LT`
 * `SCMP_CMP_LE`
@@ -375,3 +374,8 @@ Its value is either slave, private, or shared.
 ```json
     "rootfsPropagation": "slave",
 ```
+
+[libseccomp]: https://github.com/seccomp/libseccomp/tree/v2.2.3
+[libseccomp-architecture]: https://www.kernel.org/doc/Documentation/prctl/seccomp_filter.txt
+[libseccomp-actions]: https://github.com/seccomp/libseccomp/blob/v2.2.3/include/seccomp.h.in#L210-L233
+[libseccomp-operators]: https://github.com/seccomp/libseccomp/blob/v2.2.3/include/seccomp.h.in#L63-L76


### PR DESCRIPTION
Don't punt readers to libseccomp, because this spec is supposed to be
[a self-sufficient contract between the bundle-author and the
runtime][1].  The bundle-author shouldn't care if the runtime uses
libseccomp, or which version of libseccomp it uses.  But they can rely
on the listed constants being supported (and we may want to bring over
brief descriptions to go along with the constants themselves).

Runtime authors, on the other hand, may want to know that v2.2.3 of
libseccomp provides all the required constants.  I've added links to
the libseccomp 2.2.3 header from which these constants were extracted,
and that should be enough of a hint for bundle authors to use a
compatible libseccomp version (if they want to use libseccomp at all).

Spun off from #200, which has since landed.

[1]: https://github.com/opencontainers/specs/pull/200/files#r40257217