### PR TITLE
convert **name** to **`name`**

### DIFF
--- a/config.md
+++ b/config.md
@@ -10,7 +10,7 @@ Below is a detailed description of each field defined in the configuration forma
 
 ## Manifest version
 
-* **version** (string, required) must be in [SemVer v2.0.0](http://semver.org/spec/v2.0.0.html) format and specifies the version of the OCF specification with which the container bundle complies. The Open Container spec follows semantic versioning and retains forward and backward compatibility within major versions. For example, if an implementation is compliant with version 1.0.1 of the spec, it is compatible with the complete 1.x series.
+* **`version`** (string, required) must be in [SemVer v2.0.0](http://semver.org/spec/v2.0.0.html) format and specifies the version of the OCF specification with which the container bundle complies. The Open Container spec follows semantic versioning and retains forward and backward compatibility within major versions. For example, if an implementation is compliant with version 1.0.1 of the spec, it is compatible with the complete 1.x series.
 
 *Example*
 
@@ -22,8 +22,8 @@ Below is a detailed description of each field defined in the configuration forma
 
 Each container has exactly one *root filesystem*, specified in the *root* object:
 
-* **path** (string, required) Specifies the path to the root filesystem for the container, relative to the path where the manifest is. A directory MUST exist at the relative path declared by the field.
-* **readonly** (bool, optional) If true then the root filesystem MUST be read-only inside the container. Defaults to false.
+* **`path`** (string, required) Specifies the path to the root filesystem for the container, relative to the path where the manifest is. A directory MUST exist at the relative path declared by the field.
+* **`readonly`** (bool, optional) If true then the root filesystem MUST be read-only inside the container. Defaults to false.
 
 *Example*
 
@@ -39,8 +39,8 @@ Each container has exactly one *root filesystem*, specified in the *root* object
 You can add array of mount points inside container as `mounts`.
 Each record in this array must have configuration in [runtime config](runtime-config.md#mount-configuration).
 
-* **name** (string, required) Name of mount point. Used for config lookup.
-* **path** (string, required) Destination of mount point: path inside container.
+* **`name`** (string, required) Name of mount point. Used for config lookup.
+* **`path`** (string, required) Destination of mount point: path inside container.
 
 *Example*
 
@@ -67,17 +67,17 @@ Each record in this array must have configuration in [runtime config](runtime-co
 
 ## Process configuration
 
-* **terminal** (bool, optional) specifies whether you want a terminal attached to that process. Defaults to false.
-* **cwd** (string, optional) is the working directory that will be set for the executable.
-* **env** (array of strings, optional) contains a list of variables that will be set in the process's environment prior to execution. Elements in the array are specified as Strings in the form "KEY=value". The left hand side must consist solely of letters, digits, and underscores `_` as outlined in [IEEE Std 1003.1-2001](http://pubs.opengroup.org/onlinepubs/009695399/basedefs/xbd_chap08.html).
-* **args** (string, required) executable to launch and any flags as an array. The executable is the first element and must be available at the given path inside of the rootfs. If the executable path is not an absolute path then the search $PATH is interpreted to find the executable.
+* **`terminal`** (bool, optional) specifies whether you want a terminal attached to that process. Defaults to false.
+* **`cwd`** (string, optional) is the working directory that will be set for the executable.
+* **`env`** (array of strings, optional) contains a list of variables that will be set in the process's environment prior to execution. Elements in the array are specified as Strings in the form "KEY=value". The left hand side must consist solely of letters, digits, and underscores `_` as outlined in [IEEE Std 1003.1-2001](http://pubs.opengroup.org/onlinepubs/009695399/basedefs/xbd_chap08.html).
+* **`args`** (string, required) executable to launch and any flags as an array. The executable is the first element and must be available at the given path inside of the rootfs. If the executable path is not an absolute path then the search $PATH is interpreted to find the executable.
 
 The user for the process is a platform-specific structure that allows specific control over which user the process runs as.
 For Linux-based systems the user structure has the following fields:
 
-* **uid** (int, required) specifies the user id.
-* **gid** (int, required) specifies the group id.
-* **additionalGids** (array of ints, optional) specifies additional group ids to be added to the process.
+* **`uid`** (int, required) specifies the user id.
+* **`gid`** (int, required) specifies the group id.
+* **`additionalGids`** (array of ints, optional) specifies additional group ids to be added to the process.
 
 *Example (Linux)*
 
@@ -103,7 +103,7 @@ For Linux-based systems the user structure has the following fields:
 
 ## Hostname
 
-* **hostname** (string, optional) as it is accessible to processes running inside.
+* **`hostname`** (string, optional) as it is accessible to processes running inside.
 
 *Example*
 
@@ -113,8 +113,8 @@ For Linux-based systems the user structure has the following fields:
 
 ## Platform-specific configuration
 
-* **os** (string, required) specifies the operating system family this image must run on. Values for os must be in the list specified by the Go Language document for [`$GOOS`](https://golang.org/doc/install/source#environment).
-* **arch** (string, required) specifies the instruction set for which the binaries in the image have been compiled. Values for arch must be in the list specified by the Go Language document for [`$GOARCH`](https://golang.org/doc/install/source#environment).
+* **`os`** (string, required) specifies the operating system family this image must run on. Values for os must be in the list specified by the Go Language document for [`$GOOS`](https://golang.org/doc/install/source#environment).
+* **`arch`** (string, required) specifies the instruction set for which the binaries in the image have been compiled. Values for arch must be in the list specified by the Go Language document for [`$GOARCH`](https://golang.org/doc/install/source#environment).
 
 ```json
 "platform": {

--- a/runtime-config-linux.md
+++ b/runtime-config-linux.md
@@ -38,13 +38,13 @@ Also, when a path is specified, a runtime MUST assume that the setup for that pa
 
 #### Namespace types
 
-* **pid** processes inside the container will only be able to see other processes inside the same container.
-* **network** the container will have its own network stack.
-* **mount** the container will have an isolated mount table.
-* **ipc** processes inside the container will only be able to communicate to other processes inside the same
+* **`pid`** processes inside the container will only be able to see other processes inside the same container.
+* **`network`** the container will have its own network stack.
+* **`mount`** the container will have an isolated mount table.
+* **`ipc`** processes inside the container will only be able to communicate to other processes inside the same
 container via system level IPC.
-* **uts** the container will be able to have its own hostname and domain name.
-* **user** the container will be able to remap user and group IDs from the host to local users and groups
+* **`uts`** the container will be able to have its own hostname and domain name.
+* **`user`** the container will be able to remap user and group IDs from the host to local users and groups
 within the container.
 
 ## Devices
@@ -52,16 +52,16 @@ within the container.
 Devices is an array specifying the list of devices to be created in the container.
 Next parameters can be specified:
 
-* **type** - type of device: `c`, `b`, `u` or `p`. More info in `man mknod`
-* **path** - full path to device inside container
-* **major, minor** - major, minor numbers for device. More info in `man mknod`.
+* **`type`** - type of device: `c`, `b`, `u` or `p`. More info in `man mknod`
+* **`path`** - full path to device inside container
+* **`major, minor`** - major, minor numbers for device. More info in `man mknod`.
                  There is special value: `-1`, which means `*` for `device`
                  cgroup setup.
-* **permissions** - cgroup permissions for device. A composition of `r`
+* **`permissions`** - cgroup permissions for device. A composition of `r`
                 (read), `w` (write), and `m` (mknod).
-* **fileMode** - file mode for device file
-* **uid** - uid of device owner
-* **gid** - gid of device owner
+* **`fileMode`** - file mode for device file
+* **`uid`** - uid of device owner
+* **`gid`** - gid of device owner
 
 ```json
    "devices": [

--- a/runtime-config.md
+++ b/runtime-config.md
@@ -62,9 +62,9 @@ Values are objects with configuration of mount points.
 The parameters are similar to the ones in [the Linux mount system call](http://man7.org/linux/man-pages/man2/mount.2.html).
 Only [mounts from the portable config](config.md#mount-points) will be mounted.
 
-* **type** (string, required) Linux, *filesystemtype* argument supported by the kernel are listed in */proc/filesystems* (e.g., "minix", "ext2", "ext3", "jfs", "xfs", "reiserfs", "msdos", "proc", "nfs", "iso9660"). Windows: ntfs
-* **source** (string, required) a device name, but can also be a directory name or a dummy. Windows, the volume name that is the target of the mount point. \\?\Volume\{GUID}\ (on Windows source is called target)
-* **options** (list of strings, optional) in the fstab format [https://wiki.archlinux.org/index.php/Fstab](https://wiki.archlinux.org/index.php/Fstab).
+* **`type`** (string, required) Linux, *filesystemtype* argument supported by the kernel are listed in */proc/filesystems* (e.g., "minix", "ext2", "ext3", "jfs", "xfs", "reiserfs", "msdos", "proc", "nfs", "iso9660"). Windows: ntfs
+* **`source`** (string, required) a device name, but can also be a directory name or a dummy. Windows, the volume name that is the target of the mount point. \\?\Volume\{GUID}\ (on Windows source is called target)
+* **`options`** (list of strings, optional) in the fstab format [https://wiki.archlinux.org/index.php/Fstab](https://wiki.archlinux.org/index.php/Fstab).
 
 *Example (Linux)*
 

--- a/runtime-config.md
+++ b/runtime-config.md
@@ -7,7 +7,7 @@ Presently there are `Prestart` and `Poststop`.
 
 * [`Prestart`](#pre-start) is a list of hooks to be run before the container process is executed
 * [`Poststop`](#post-stop)is a list of hooks to be run after the container process exits
-	
+
 Hooks allow one to run code before/after various lifecycle events of the container.
 Hooks MUST be called in the listed order.
 The state of the container is passed to the hooks over stdin, so the hooks could get the information they need to do their work.

--- a/runtime.md
+++ b/runtime.md
@@ -9,10 +9,10 @@ On Linux based systems the state information should be stored in `/run/openconta
 The directory structure for a container is `/run/opencontainer/containers/<containerID>/state.json`.
 By providing a default location that container state is stored external applications can find all containers running on a system.
 
-* **version** (string) Version of the OCI specification used when creating the container.
-* **id** (string) ID is the container's ID.
-* **pid** (int) Pid is the ID of the main process within the container.
-* **root** (string) Root is the path to the container's bundle directory.
+* **`version`** (string) Version of the OCI specification used when creating the container.
+* **`id`** (string) ID is the container's ID.
+* **`pid`** (int) Pid is the ID of the main process within the container.
+* **`root`** (string) Root is the path to the container's bundle directory.
 
 The ID is provided in the state because hooks will be executed with the state as the payload.
 This allows the hook to perform clean and teardown logic after the runtime destroys its own state.


### PR DESCRIPTION
convert ```**name**``` to ```**`name`**```

we have both styles in the `*.md`, we should use only one of the styles.
And **`name`** is much prettier than **name** in the result,
so we use **`name`**

Signed-off-by: Lai Jiangshan <jiangshanlai@gmail.com>