### PR TITLE
.travis.yml: add go 1.5.1, update from 1.4.2 to 1.4.3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,7 @@
 language: go
 go:
-  - 1.4.2
+  - 1.5.1
+  - 1.4.3
   - 1.3.3
 
 sudo: false


### PR DESCRIPTION
Signed-off-by: Antonio Murdaca <runcom@linux.com>