### PR TITLE
Cleanup bundle.md

### DIFF
--- a/bundle.md
+++ b/bundle.md
@@ -1,39 +1,27 @@
-# Bundle
+# Filesystem Bundle
 
 ## Container Format
 
-This section defines a format for encoding a container as a *bundle* - a directory organized in a certain way, and containing all the necessary data and metadata for any compliant runtime to perform all standard operations against it.
+This section defines a format for encoding a container as a *filesystem bundle* - a set of files organized in a certain way, and containing all the necessary data and metadata for any compliant runtime to perform all standard operations against it.
 See also [OS X application bundles](http://en.wikipedia.org/wiki/Bundle_%28OS_X%29) for a similar use of the term *bundle*.
 
-The format does not define distribution.
-In other words, it only specifies how a container must be stored on a local filesystem, for consumption by a runtime.
-It does not specify how to transfer a container between computers, how to discover containers, or assign names or versions to them.
-Any distribution method capable of preserving the original layout of a container, as specified here, is considered compliant.
+The definition of a bundle is only concerned with how a container, and its configuration data, are stored on a local file system so that it can be consumed by a compliant runtime.
 
-A standard container bundle is made of the following 3 parts:
+A Standard Container bundle contains all the information needed to load and run a container.
+This includes the following three artifacts which MUST all reside in the same directory on the local filesystem:
 
-- A top-level directory holding everything else
-- One or more content directories
-- A configuration file
+1. `config.json` : immutable, host independent configuration.
+This REQUIRED file, which MUST be named `config.json`, contains settings that are host independent and application specific such as security permissions, environment variables and arguments.
+See [`config.json`](config.md) for more details.
 
-## Directory layout
+2. `runtime.json` : mutable, host dependent configuration.
+This REQUIRED file, which MUST be named `runtime.json`, contains settings that are host specific such as memory limits, local device access and mount sources.
+The goal is that the bundle can be moved as a unit to another runtime and run the same application if `runtime.json` is reconfigured.
+See [`runtime.json`](runtime-config.md) for more details.
 
-A Standard Container bundle is a directory containing all the content needed to load and run a container.
-This includes two configuration files `config.json` and `runtime.json`, and a rootfs directory.
-The `config.json` file contains settings that are host independent and application specific such as security permissions, environment variables and arguments.
-The `runtime.json` file contains settings that are host specific such as memory limits, local device access and mount points.
-The goal is that the bundle can be moved as a unit to another machine and run the same application if `runtime.json` is removed or reconfigured.
+3. A directory representing the root filesystem of the container.
+While the name of this REQUIRED directory may be arbitrary, users should consider using a conventional name, such as `rootfs`.
+This directory MUST be referenced from within the `config.json` file.
 
-Configuration file syntax and semantics:
-
-* [`config.json`](config.md) (immutable, host independent configuration)
-* [`runtime.json`](runtime-config.md) (mutable, host dependent configuration)
-
-A single `rootfs` directory MUST be in the same directory as the `config.json`.
-The names of the directories may be arbitrary, but users should consider using conventional names as in the example below.
-
-```
-config.json
-runtime.json
-rootfs/
-```
+While these three artifacts MUST all be present in a single directory on the local filesytem, that directory itself is not part of the bundle.
+In other words, a tar archive of a *bundle* will have these artifacts at the root of the archive, not nested within a top-level directory.


### PR DESCRIPTION
Mainly just moved stuff around, but also tried to add some clarity around
what is required w.r.t. naming and location of files/dirs.

But to highlight some things that I want to make sure we ALL agree on:
- config.json and runtime.json MUST use those exact names
- name of rootfs dir is user defined - but nudge them towards `rootfs`
- all 3 (config.json, runtime.json and rootfs dir) MUST all be in the same location/dir
- that 'location' is NOT part of the bundle itself (this may matter when someone defines the on-the-wire format of a bundle)

Signed-off-by: Doug Davis <dug@us.ibm.com>