### PR TITLE
runtime: Change 'destroys state' to 'removes container'

### DIFF
--- a/runtime.md
+++ b/runtime.md
@@ -18,7 +18,7 @@ The `state.json` file MUST contain all of the following properties:
 This MUST be unique across all containers on this host.
 There is no requirement that it be unique across hosts.
 The ID is provided in the state because hooks will be executed with the state as the payload.
-This allows the hooks to perform cleanup and teardown logic after the runtime destroys its own state.
+This allows the hooks to perform cleanup and teardown logic after the runtime removes the container.
 * **`pid`**: (int) is the ID of the main process within the container, as seen by the host.
 * **`bundlePath`**: (string) is the absolute path to the container's bundle directory.
 This is provided so that consumers can find the container's configuration and root filesystem on the host.


### PR DESCRIPTION
The runtime hasn't destroyed any of it's internal state before calling
the post-stop hooks (it still knows the state JSON it's going to pipe
to the hooks, and could still have the original configs in memory if
it wanted to keep that around).  What's changed by the time we have
the post-stop hooks (and the reason to keep an explicit container ID
around) is that the *kernel* state (namespaces and cgroups) might be
gone by the time the post-stop hooks are run (any PID namespace that
was created by the container process will certainly be gone by then).
This commit updates the wording to more clearly mean "after removing
namespaces and cgroups" and to avoid folks interpreting it as "after
releasing some internal-to-the-runtime-process memory".

This line landed as part of #87, and the only review so far seems to
have been an [“it's” → “its” typo fix][1].

If the “removes the container” phrasing bothers people for some
reason, I'm happy to reroll.  I'm also happy to put the “destroys its
own state” phrasing back in if someone can clarify what state it was
talking about and it turns out that there is some important
internal-to-the-runtime entity that is being destroyed by post-stop
time (in which case I'd like to add additional wording to clarify that
entity in the spec).

[1]: https://github.com/opencontainers/specs/pull/87#discussion_r38236155