### PR TITLE
config: Require a new UTS namespace for config.json's hostname

### DIFF
--- a/config.md
+++ b/config.md
@@ -104,7 +104,7 @@ For Linux-based systems the user structure has the following fields:
 
 ## Hostname
 
-* **`hostname`** (string, optional) as it is accessible to processes running inside.
+* **`hostname`** (string, optional) as it is accessible to processes running inside.  On Linux, you can only set this if your bundle creates a new [UTS namespace][uts-namespace].
 
 *Example*
 
@@ -126,3 +126,5 @@ For Linux-based systems the user structure has the following fields:
 
 Interpretation of the platform section of the JSON file is used to find which platform-specific sections may be available in the document.
 For example, if `os` is set to `linux`, then a JSON object conforming to the [Linux-specific schema](config-linux.md) SHOULD be found at the key `linux` in the `config.json`.
+
+[uts-namespace]: http://man7.org/linux/man-pages/man7/namespaces.7.html


### PR DESCRIPTION
The UTS namespace is for [hostnames and NIS domain names][1].  Without
a new namespace, the hostname entry would clobber the host
environment's hostname.

Clobbering the host's hostname or a joined-namespace's hostname might
be acceptable for folks who trust their bundles, but it's not allowed
by the “error out if the config specifies anything else related to
that namespace” language that landed in 02b456e9 (Clarify behavior
around namespaces paths, 2015-09-08, #158).

[1]: http://man7.org/linux/man-pages/man7/namespaces.7.html