### PR TITLE
Adding Vishnu Kannan as a Maintainer.

### DIFF
--- a/MAINTAINERS
+++ b/MAINTAINERS
@@ -1,7 +1,6 @@
 Michael Crosby <michael@docker.com> (@crosbymichael)
 Alexander Morozov <lk4d4@docker.com> (@LK4D4)
-Rohit Jnagal <jnagal@google.com> (@rjnagal)
-Victor Marmol <vmarmol@google.com> (@vmarmol)
+Vishnu Kannan <vishnuk@google.com> (@vishnuk)
 Mrunal Patel <mpatel@redhat.com> (@mrunalp)
 Vincent Batts <vbatts@redhat.com> (@vbatts)
 Daniel, Dao Quang Minh <dqminh89@gmail.com> (@dqminh)


### PR DESCRIPTION
Removing Victor Marmol and Rohit Jnagal from being Maintainers.

Signed-off-by: Vishnu kannan <vishnuk@google.com>

cc @crosbymichael @vmarmol @rjnagal 