### PR TITLE
Allow the namespace path to be container ID

### DIFF
--- a/runtime-config-linux.md
+++ b/runtime-config-linux.md
@@ -9,6 +9,8 @@ For more information, see [the man page](http://man7.org/linux/man-pages/man7/na
 Namespaces are specified in the spec as an array of entries.
 Each entry has a type field with possible values described below and an optional path element.
 If a path is specified, that particular file is used to join that type of namespace.
+If the specified path doesn't container any '/', it is considerred as a container ID rather than a file path and the target namespace is resolved from the information from the [state file](runtime.md#State) of the target container.
+For example, if the uts namespace path is "oc-container", it is considerred as a container ID and the pid (say 4422) can be fetched from its state file, thus the target namespace file is "/proc/4422/ns/uts".
 Also, when a path is specified, a runtime MUST assume that the setup for that particular namespace has already been done and error out if the config specifies anything else related to that namespace.
 
 ```json


### PR DESCRIPTION
In numerous cases, we need to share the container's namespace with
an existing container. In these cases, we have to resolve the namespace
file step by step. For example, the docker resolves it from the
information of the target container in several steps and saves it to the
config (now it is in-memory config, it will be runtime.json in future).
We can move the resolving operation to the oci implementations
and allow the namespace path to be container ID in the spec.

Reasons:
* it really repsents "sharing the namespace with existing container".
   (it is the most important reason.)
* the administrator writes the runtime.json much conveniently and
   less error. And it is better readability and the administrator
   is easier to check the runtime.json which is written by himself
   or by other human or by other tools.
* we may have more orchestra tools than oci implementations,
   the resolving operation is better in implementations than
   in the tools.

Signed-off-by: Lai Jiangshan <jiangshanlai@gmail.com>