### PR TITLE
IsHostUnprivileged flag for host

### DIFF
--- a/runtime_config_linux.go
+++ b/runtime_config_linux.go
@@ -14,6 +14,9 @@ type LinuxRuntimeSpec struct {
 
 // LinuxRuntime hosts the Linux-only runtime information
 type LinuxRuntime struct {
+	// Indicates if the host is unprivileged
+	// Used by libcontainer to check whether to mknod and write to devices cgroup
+	IsHostUnprivileged bool `json:"isHostUnprivileged"`
 	// UIDMapping specifies user mappings for supporting user namespaces on linux.
 	UIDMappings []IDMapping `json:"uidMappings"`
 	// GIDMapping specifies group mappings for supporting user namespaces on linux.


### PR DESCRIPTION
This flag indicates that the host that is launching the container is
unprivileged. Setting this to true ensures that implementations will be
able avoid erroring on actions that unprivileged hosts cannot
perform(such as mknod).

An example of this is in runc: https://github.com/opencontainers/runc/pull/351
Signed-off-by: Abin Shahab <ashahab@altiscale.com>