### PR TITLE
config: linux: update description of PidsLimit

### DIFF
--- a/runtime_config_linux.go
+++ b/runtime_config_linux.go
@@ -182,7 +182,7 @@ type CPU struct {
 
 // Pids for Linux cgroup 'pids' resource management (Linux 4.3)
 type Pids struct {
-	// Maximum number of PIDs. A value < 0 implies "no limit".
+	// Maximum number of PIDs. A value <= 0 indicates "no limit".
 	Limit int64 `json:"limit"`
 }
 


### PR DESCRIPTION
Fix a misleading comment for how PidsLimit works when given a limit of
0. A limit of 0 is identical to a limit of 1, and so there is no reason
to distinguish the two. Since the default value for integers in Go is 0,
it makes more sense to make the default value mean that there is no
limit.

Signed-off-by: Aleksa Sarai <cyphar@cyphar.com> (github: cyphar)