### PR TITLE
cgroup: Add support for memory.kmem.tcp.limit_in_bytes

### DIFF
--- a/runtime-config-linux.md
+++ b/runtime-config-linux.md
@@ -201,6 +201,8 @@ The following parameters can be specified to setup the controller:
 
 * **`kernel`** *(uint64, optional)* - sets hard limit for kernel memory
 
+* **`kernelTCP`** *(uint64, optional)* - sets hard limit for kernel memory in tcp using
+
 * **`swappiness`** *(uint64, optional)* - sets swappiness parameter of vmscan (See sysctl's vm.swappiness)
 
 ###### Example
@@ -211,6 +213,7 @@ The following parameters can be specified to setup the controller:
         "reservation": 0,
         "swap": 0,
         "kernel": 0,
+        "kernelTCP": 0,
         "swappiness": -1
     }
 ```

--- a/runtime_config_linux.go
+++ b/runtime_config_linux.go
@@ -158,6 +158,8 @@ type Memory struct {
 	Swap uint64 `json:"swap"`
 	// Kernel memory limit (in bytes)
 	Kernel uint64 `json:"kernel"`
+	// Kernel memory limit for tcp (in bytes)
+	KernelTCP uint64 `json:"kernelTCP"`
 	// How aggressive the kernel will swap memory pages. Range from 0 to 100. Set -1 to use system default
 	Swappiness uint64 `json:"swappiness"`
 }


### PR DESCRIPTION
Signed-off-by: Dongsheng Yang <yangds.fnst@cn.fujitsu.com>