### PR TITLE
ROADMAP: Link to list thread on a single, unified config file

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -20,6 +20,10 @@ Although OCI doesn't define a transport method we should have a cryptographic di
 There are some discussions about having `runtime.json` being optional for containers and specifying defaults.
 Runtimes would use this standard set of defaults for containers and `runtime.json` would provide overrides for fine tuning of these extra host or platform specific settings.
 
+Proposals:
+
+* [Drop `runtime.json`, returning to the single `config.json` we had before #88](https://groups.google.com/a/opencontainers.org/forum/#!topic/dev/0QbyJDM9fWY)
+
 *Owner:*  
 
 ### Define Container Lifecycle


### PR DESCRIPTION
I expect folks with competing views will also [post to the list][1],
either advocating their desired approach (in new threads?) or poking
holes in my proposal.  So having a list of links here will make it
easier for the decision makers to keep track of the proposals while
they review their relative merits.

[1]: https://github.com/opencontainers/specs/blob/v0.1.1/README.md#contributing