### PR TITLE
Change the behavior when cgroupsPath is absent

### DIFF
--- a/runtime-config-linux.md
+++ b/runtime-config-linux.md
@@ -146,7 +146,7 @@ For more information, see the [kernel cgroups documentation](https://www.kernel.
 
 The path to the cgroups can be specified in the Spec via `cgroupsPath`.
 `cgroupsPath` is expected to be relative to the cgroups mount point.
-If not specified, cgroups will be created under '/'.
+If `cgroupsPath` is not specified, implementations can define the default cgroup path.
 Implementations of the Spec can choose to name cgroups in any manner.
 The Spec does not include naming schema for cgroups.
 The Spec does not support [split hierarchy](https://www.kernel.org/doc/Documentation/cgroups/unified-hierarchy.txt).


### PR DESCRIPTION
The former definition was join "/" when `cgroupsPath` is absent, it's
not clear whether to join the root cgroup or create a sub cgroup under "/".

Join root cgroup would be a bad idea cause that's not what a container
should do. And craete a sub cgroup would be missing definition about what
the cgroup name should that be.

So I think we should leave this to implementations what the default
cgroup path should be.

Signed-off-by: Qiang Huang <h.huangqiang@huawei.com>