### PR TITLE
Clarify backwards compatibility for major version 0

### DIFF
--- a/config.md
+++ b/config.md
@@ -10,7 +10,7 @@ Below is a detailed description of each field defined in the configuration forma
 
 ## Manifest version
 
-* **`version`** (string, required) must be in [SemVer v2.0.0](http://semver.org/spec/v2.0.0.html) format and specifies the version of the OCF specification with which the container bundle complies. The Open Container spec follows semantic versioning and retains forward and backward compatibility within major versions. For example, if an implementation is compliant with version 1.0.1 of the spec, it is compatible with the complete 1.x series.
+* **`version`** (string, required) must be in [SemVer v2.0.0](http://semver.org/spec/v2.0.0.html) format and specifies the version of the OCF specification with which the container bundle complies. The Open Container spec follows semantic versioning and retains forward and backward compatibility within major versions. For example, if an implementation is compliant with version 1.0.1 of the spec, it is compatible with the complete 1.x series. NOTE that there is no guarantee for forward or backward compatibility for version 0.x.
 
 *Example*
 


### PR DESCRIPTION
I think we agreed on this, but there is no docs for this, and it is easy to cause confusing as https://github.com/opencontainers/runc/pull/406 and https://github.com/opencontainers/runc/pull/406#issuecomment-157685174

Signed-off-by: Qiang Huang <h.huangqiang@huawei.com>