### PR TITLE
Add hyphen for host specific

### DIFF
--- a/bundle.md
+++ b/bundle.md
@@ -10,13 +10,13 @@ The definition of a bundle is only concerned with how a container, and its confi
 A Standard Container bundle contains all the information needed to load and run a container.
 This includes the following three artifacts which MUST all reside in the same directory on the local filesystem:
 
-1. `config.json` : contains host independent configuration data.
-This REQUIRED file, which MUST be named `config.json`, contains settings that are host independent and application specific such as security permissions, environment variables and arguments.
+1. `config.json` : contains host-independent configuration data.
+This REQUIRED file, which MUST be named `config.json`, contains settings that are host-independent and application-specific such as security permissions, environment variables and arguments.
 When the bundle is packaged up for distribution, this file MUST be included.
 See [`config.json`](config.md) for more details.
 
 2. `runtime.json` : contains host-specific configuration data.
-This REQUIRED file, which MUST be named `runtime.json`, contains settings that are host specific such as mount sources and hooks.
+This REQUIRED file, which MUST be named `runtime.json`, contains settings that are host-specific such as mount sources and hooks.
 The goal is that the bundle can be moved as a unit to another runtime and run the same application once a host-specific `runtime.json` is defined.
 When the bundle is packaged up for distribution, this file MUST NOT be included.
 See [`runtime.json`](runtime-config.md) for more details.


### PR DESCRIPTION
We have `host-specific` and `host specific` in the same doc,
add hyphen to keep consistency.

Signed-off-by: Qiang Huang <h.huangqiang@huawei.com>