### PR TITLE
*: printable documents

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,43 @@
+
+DOCKER ?= $(shell which docker)
+DOC_FILES := \
+	README.md \
+	code-of-conduct.md \
+	principles.md \
+	ROADMAP.md \
+	implementations.md \
+	bundle.md \
+	runtime.md \
+	runtime-linux.md \
+	config.md \
+	config-linux.md \
+	runtime-config.md \
+	runtime-config-linux.md
+
+docs: pdf html
+
+pdf:
+	@mkdir -p output/ && \
+	$(DOCKER) run \
+	-it \
+	--rm \
+	-v $(shell pwd)/:/input/:ro \
+	-v $(shell pwd)/output/:/output/ \
+	-u $(shell id -u) \
+	vbatts/pandoc -f markdown_github -t latex -o /output/docs.pdf $(patsubst %,/input/%,$(DOC_FILES)) && \
+	ls -sh $(shell readlink -f output/docs.pdf)
+
+html:
+	@mkdir -p output/ && \
+	$(DOCKER) run \
+	-it \
+	--rm \
+	-v $(shell pwd)/:/input/:ro \
+	-v $(shell pwd)/output/:/output/ \
+	-u $(shell id -u) \
+	vbatts/pandoc -f markdown_github -t html5 -o /output/docs.html $(patsubst %,/input/%,$(DOC_FILES)) && \
+	ls -sh $(shell readlink -f output/docs.html)
+
+clean:
+	rm -rf output/ *~
+


### PR DESCRIPTION
I do not like having this build step of printable documentation
depending on pulling a container, but the pandoc+latex combo is a big
bundle. This is the minimal and cleanest approach for using these tools,
for now.

Just run `make pdf && xdg-open ./output/docs.pdf`

Per: https://github.com/opencontainers/specs/blob/master/ROADMAP.md#printablecompiled-spec

Signed-off-by: Vincent Batts <vbatts@hashbangbash.com>