### PR TITLE
index.md: Add a single-page overview for easy printing

### DIFF
--- a/_includes/README.md
+++ b/_includes/README.md
@@ -1,0 +1,144 @@
+# Open Container Specifications
+
+[Open Container Initiative](http://www.opencontainers.org/) Specifications for standards on Operating System process and application containers.
+
+
+Table of Contents
+
+- [Container Principles](principles.md)
+- [Filesystem Bundle](bundle.md)
+- Configuration
+  - [Container Configuration](config.md)
+  - [Container Configuration (Linux-specific)](config-linux.md)
+  - [Runtime Configuration](runtime-config.md)
+  - [Runtime Configuration (Linux-specific)](runtime-config-linux.md)
+- [Runtime and Lifecycle](runtime.md)
+  - [Linux Specific Runtime](runtime-linux.md)
+- [Implementations](implementations.md)
+
+# Use Cases
+
+To provide context for users the following section gives example use cases for each part of the spec.
+
+## Filesystem Bundle & Configuration
+
+- A user can create a root filesystem and configuration, with low-level OS and host specific details, and launch it as a container under an Open Container runtime.
+
+# Releases
+
+There is a loose [Road Map](https://github.com/opencontainers/specs/wiki/RoadMap:) on the wiki.
+During the `0.x` series of OCI releases we make no backwards compatibility guarantees and intend to break the schema during this series.
+
+# Contributing
+
+Development happens on GitHub for the spec.
+Issues are used for bugs and actionable items and longer discussions can happen on the [mailing list](#mailing-list).
+
+The specification and code is licensed under the Apache 2.0 license found in the `LICENSE` file of this repository.
+
+## Code of Conduct
+
+Participation in the OpenContainers community is governed by [OpenContainer's Code of Conduct](code-of-conduct.md).
+
+## Discuss your design
+
+The project welcomes submissions, but please let everyone know what you are working on.
+
+Before undertaking a nontrivial change to this specification, send mail to the [mailing list](#mailing-list) to discuss what you plan to do.
+This gives everyone a chance to validate the design, helps prevent duplication of effort, and ensures that the idea fits.
+It also guarantees that the design is sound before code is written; a GitHub pull-request is not the place for high-level discussions.
+
+Typos and grammatical errors can go straight to a pull-request.
+When in doubt, start on the [mailing-list](#mailing-list).
+
+## Weekly Call
+
+The contributors and maintainers of the project have a weekly meeting Wednesdays at 10:00 AM PST.
+Everyone is welcome to participate in the [BlueJeans call][BlueJeans].
+An initial agenda will be posted to the [mailing list](#mailing-list) earlier in the week, and everyone is welcome to propose additional topics or suggest other agenda alterations there.
+Minutes are posted to the [mailing list](#mailing-list) and minutes from past calls are archived to the [wiki](https://github.com/opencontainers/specs/wiki) for those who are unable to join the call.
+
+## Mailing List
+
+You can subscribe and join the mailing list on [Google Groups](https://groups.google.com/a/opencontainers.org/forum/#!forum/dev).
+
+## IRC
+
+OCI discussion happens on #opencontainers on Freenode.
+
+## Markdown style
+
+To keep consistency throughout the Markdown files in the Open Container spec all files should be formatted one sentence per line.
+This fixes two things: it makes diffing easier with git and it resolves fights about line wrapping length.
+For example, this paragraph will span three lines in the Markdown source.
+
+## Git commit
+
+### Sign your work
+
+The sign-off is a simple line at the end of the explanation for the patch, which certifies that you wrote it or otherwise have the right to pass it on as an open-source patch.
+The rules are pretty simple: if you can certify the below (from [developercertificate.org](http://developercertificate.org/)):
+
+```
+Developer Certificate of Origin
+Version 1.1
+
+Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
+660 York Street, Suite 102,
+San Francisco, CA 94110 USA
+
+Everyone is permitted to copy and distribute verbatim copies of this
+license document, but changing it is not allowed.
+
+
+Developer's Certificate of Origin 1.1
+
+By making a contribution to this project, I certify that:
+
+(a) The contribution was created in whole or in part by me and I
+    have the right to submit it under the open source license
+    indicated in the file; or
+
+(b) The contribution is based upon previous work that, to the best
+    of my knowledge, is covered under an appropriate open source
+    license and I have the right under that license to submit that
+    work with modifications, whether created in whole or in part
+    by me, under the same open source license (unless I am
+    permitted to submit under a different license), as indicated
+    in the file; or
+
+(c) The contribution was provided directly to me by some other
+    person who certified (a), (b) or (c) and I have not modified
+    it.
+
+(d) I understand and agree that this project and the contribution
+    are public and that a record of the contribution (including all
+    personal information I submit with it, including my sign-off) is
+    maintained indefinitely and may be redistributed consistent with
+    this project or the open source license(s) involved.
+```
+
+then you just add a line to every git commit message:
+
+    Signed-off-by: Joe Smith <joe@gmail.com>
+
+using your real name (sorry, no pseudonyms or anonymous contributions.)
+
+You can add the sign off when creating the git commit via `git commit -s`.
+
+### Commit Style
+
+Simple house-keeping for clean git history.
+Read more on [How to Write a Git Commit Message](http://chris.beams.io/posts/git-commit/) or the Discussion section of [`git-commit(1)`](http://git-scm.com/docs/git-commit).
+
+1. Separate the subject from body with a blank line
+2. Limit the subject line to 50 characters
+3. Capitalize the subject line
+4. Do not end the subject line with a period
+5. Use the imperative mood in the subject line
+6. Wrap the body at 72 characters
+7. Use the body to explain what and why vs. how
+  * If there was important/useful/essential conversation or information, copy or include a reference
+8. When possible, one keyword to scope the change in the subject (i.e. "README: ...", "runtime: ...")
+
+[BlueJeans]: https://bluejeans.com/1771332256/

--- a/_includes/ROADMAP.md
+++ b/_includes/ROADMAP.md
@@ -1,0 +1,102 @@
+# OCI Specs Roadmap
+
+This document serves to provide a long term roadmap on our quest to a 1.0 version of the OCI container specification.
+Its goal is to help both maintainers and contributors find meaningful tasks to focus on and create a low noise environment.
+The items in the 1.0 roadmap can be broken down into smaller milestones that are easy to accomplish.
+The topics below are broad and small working groups will be needed for each to define scope and requirements or if the feature is required at all for the OCI level.
+Topics listed in the roadmap do not mean that they will be implemented or added but are areas that need discussion to see if they fit in to the goals of the OCI.
+
+## 1.0
+
+### Digest and Hashing
+
+A bundle is designed to be moved between hosts.
+Although OCI doesn't define a transport method we should have a cryptographic digest of the on-disk bundle that can be used to verify that a bundle is not corrupted and in an expected configuration.
+
+*Owner:* philips
+
+### Review the need for runtime.json
+
+There are some discussions about having `runtime.json` being optional for containers and specifying defaults.
+Runtimes would use this standard set of defaults for containers and `runtime.json` would provide overrides for fine tuning of these extra host or platform specific settings.
+
+*Owner:*
+
+### Define Container Lifecycle
+
+Containers have a lifecycle and being able to identify and document the lifecycle of a container is very helpful for implementations of the spec.
+The lifecycle events of a container also help identify areas to implement hooks that are portable across various implementations and platforms.
+
+*Owner:* mrunalp
+
+### Define Standard Container Actions
+
+Define what type of actions a runtime can perform on a container without imposing hardships on authors of platforms that do not support advanced options.
+
+*Owner:*
+
+### Clarify rootfs requirement in base spec
+
+Is the rootfs needed or should it just be expected in the bundle without having a field in the spec?
+
+*Owner:*
+
+### Container Definition
+
+Define what a software container is and its attributes in a cross platform way.
+
+*Owner:*
+
+### Live Container Updates
+
+Should we allow dynamic container updates to runtime options?
+
+*Owner:* vishh
+
+### Protobuf Config
+
+We currently have only one language binding for the spec and that is Go.
+If we change the specs format in the respository to be something like protobuf then the generation for multiple language bindings become effortless.
+
+*Owner:* vbatts
+
+### Validation Tooling
+
+Provide validation tooling for compliance with OCI spec and runtime environment.
+
+*Owner:* mrunalp
+
+### Testing Framework
+
+Provide a testing framework for compliance with OCI spec and runtime environment.
+
+*Owner:* liangchenye
+
+### Version Schema
+
+Decide on a robust versioning schema for the spec as it evolves.
+
+*Owner:*
+
+### Printable/Compiled Spec
+
+Reguardless of how the spec is written, ensure that it is easy to read and follow for first time users.
+
+*Owner:* vbatts
+
+### Base Config Compatibility
+
+Ensure that the base configuration format is viable for various platforms.
+
+Systems:
+
+* Solaris
+* Windows
+* Linux
+
+*Owner:*
+
+### Full Lifecycle Hooks
+Ensure that we have lifecycle hooks in the correct places with full coverage over the container lifecycle.
+
+*Owner:*

--- a/_includes/bundle.md
+++ b/_includes/bundle.md
@@ -1,0 +1,30 @@
+# Filesystem Bundle
+
+## Container Format
+
+This section defines a format for encoding a container as a *filesystem bundle* - a set of files organized in a certain way, and containing all the necessary data and metadata for any compliant runtime to perform all standard operations against it.
+See also [OS X application bundles](http://en.wikipedia.org/wiki/Bundle_%28OS_X%29) for a similar use of the term *bundle*.
+
+The definition of a bundle is only concerned with how a container, and its configuration data, are stored on a local file system so that it can be consumed by a compliant runtime.
+
+A Standard Container bundle contains all the information needed to load and run a container.
+This includes the following three artifacts which MUST all reside in the same directory on the local filesystem:
+
+1. `config.json` : contains host independent configuration data.
+This REQUIRED file, which MUST be named `config.json`, contains settings that are host independent and application specific such as security permissions, environment variables and arguments.
+When the bundle is packaged up for distribution, this file MUST be included.
+See [`config.json`](config.md) for more details.
+
+2. `runtime.json` : contains host-specific configuration data.
+This REQUIRED file, which MUST be named `runtime.json`, contains settings that are host specific such as mount sources and hooks.
+The goal is that the bundle can be moved as a unit to another runtime and run the same application once a host-specific `runtime.json` is defined.
+When the bundle is packaged up for distribution, this file MUST NOT be included.
+See [`runtime.json`](runtime-config.md) for more details.
+
+3. A directory representing the root filesystem of the container.
+While the name of this REQUIRED directory may be arbitrary, users should consider using a conventional name, such as `rootfs`.
+When the bundle is packaged up for distribution, this directory MUST be included.
+This directory MUST be referenced from within the `config.json` file.
+
+While these three artifacts MUST all be present in a single directory on the local filesytem, that directory itself is not part of the bundle.
+In other words, a tar archive of a *bundle* will have these artifacts at the root of the archive, not nested within a top-level directory.

--- a/_includes/code-of-conduct.md
+++ b/_includes/code-of-conduct.md
@@ -1,0 +1,37 @@
+# OpenContainers Code of Conduct
+
+Behave as a community member, follow the code of conduct.
+
+## Code of Conduct
+
+The OpenContainers community is made up of a mixture of professionals and volunteers from all over the world.
+
+When we disagree, we try to understand why.
+Disagreements, both social and technical, happen all the time and OpenContainers is no exception.
+It is important that we resolve disagreements and differing views constructively.
+
+This code of conduct applies both within project spaces and in public spaces when an individual is representing the project or its community.
+Participants should be aware of these concerns.
+
+We are committed to making participation in this project a harassment-free experience for everyone, regardless of level of experience, gender, gender identity and expression, sexual orientation, disability, personal appearance, body size, race, ethnicity, age, religion, or nationality.
+
+Examples of unacceptable behavior by participants include:
+
+* The use of sexualized language or imagery
+* Personal attacks
+* Trolling or insulting/derogatory comments
+* Public or private harassment
+* Publishing other's private information, such as physical or electronic addresses, without explicit permission
+* Other unethical or unprofessional conduct
+
+The OpenContainers team does not condone any statements by speakers contrary to these standards.
+The OpenContainers team reserves the right to deny participation any individual found to be engaging in discriminatory or harassing actions.
+
+Project maintainers have the right and responsibility to remove, edit, or reject comments, commits, code, wiki edits, issues, and other contributions that are not aligned to this Code of Conduct.
+By adopting this Code of Conduct, project maintainers commit themselves to fairly and consistently applying these principles to every aspect of managing this project.
+
+## Thanks 
+
+Thanks to the [Fedora Code of Conduct](https://getfedora.org/code-of-conduct) and [Contributor Covenant](http://contributor-covenant.org) for inspiration and ideas.
+
+Portions of this Code of Conduct are adapted from the Contributor Covenant, version 1.2.0, available at http://contributor-covenant.org/version/1/2/0/

--- a/_includes/config-linux.md
+++ b/_includes/config-linux.md
@@ -1,0 +1,63 @@
+# Linux-specific Container Configuration
+
+The Linux container specification uses various kernel features like namespaces, cgroups, capabilities, LSM, and file system jails to fulfill the spec.
+Additional information is needed for Linux over the [default spec configuration](config.md) in order to configure these various kernel features.
+
+## Capabilities
+
+Capabilities is an array that specifies Linux capabilities that can be provided to the process inside the container.
+Valid values are the strings for capabilities defined in [the man page](http://man7.org/linux/man-pages/man7/capabilities.7.html)
+
+```json
+   "capabilities": [
+        "CAP_AUDIT_WRITE",
+        "CAP_KILL",
+        "CAP_NET_BIND_SERVICE"
+    ]
+```
+
+## User namespace mappings
+
+```json
+    "uidMappings": [
+        {
+            "hostID": 1000,
+            "containerID": 0,
+            "size": 10
+        }
+    ],
+    "gidMappings": [
+        {
+            "hostID": 1000,
+            "containerID": 0,
+            "size": 10
+        }
+    ]
+```
+
+uid/gid mappings describe the user namespace mappings from the host to the container.
+The mappings represent how the bundle `rootfs` expects the user namespace to be setup and the runtime SHOULD NOT modify the permissions on the rootfs to realize the mapping.
+*hostID* is the starting uid/gid on the host to be mapped to *containerID* which is the starting uid/gid in the container and *size* refers to the number of ids to be mapped.
+There is a limit of 5 mappings which is the Linux kernel hard limit.
+
+## Default Devices and File Systems
+
+The Linux ABI includes both syscalls and several special file paths.
+Applications expecting a Linux environment will very likely expect these files paths to be setup correctly.
+
+The following devices and filesystems MUST be made available in each application's filesystem
+
+|     Path     |  Type  |  Notes  |
+| ------------ | ------ | ------- |
+| /proc        | [procfs](https://www.kernel.org/doc/Documentation/filesystems/proc.txt)    | |
+| /sys         | [sysfs](https://www.kernel.org/doc/Documentation/filesystems/sysfs.txt)    | |
+| /dev/null    | [device](http://man7.org/linux/man-pages/man4/null.4.html)                 | |
+| /dev/zero    | [device](http://man7.org/linux/man-pages/man4/zero.4.html)                 | |
+| /dev/full    | [device](http://man7.org/linux/man-pages/man4/full.4.html)                 | |
+| /dev/random  | [device](http://man7.org/linux/man-pages/man4/random.4.html)               | |
+| /dev/urandom | [device](http://man7.org/linux/man-pages/man4/random.4.html)               | |
+| /dev/tty     | [device](http://man7.org/linux/man-pages/man4/tty.4.html)                  | |
+| /dev/console | [device](http://man7.org/linux/man-pages/man4/console.4.html)              | |
+| /dev/pts     | [devpts](https://www.kernel.org/doc/Documentation/filesystems/devpts.txt)  | |
+| /dev/ptmx    | [device](https://www.kernel.org/doc/Documentation/filesystems/devpts.txt)  | Bind-mount or symlink of /dev/pts/ptmx |
+| /dev/shm     | [tmpfs](https://www.kernel.org/doc/Documentation/filesystems/tmpfs.txt)    | |

--- a/_includes/config.md
+++ b/_includes/config.md
@@ -1,0 +1,130 @@
+# Container Configuration file
+
+The container's top-level directory MUST contain a configuration file called `config.json`.
+For now the canonical schema is defined in [config.go](config.go) and [config_linux.go](config_linux.go), but this will be moved to a formal JSON schema over time.
+
+The configuration file contains metadata necessary to implement standard operations against the container.
+This includes the process to run, environment variables to inject, sandboxing features to use, etc.
+
+Below is a detailed description of each field defined in the configuration format.
+
+## Manifest version
+
+* **`version`** (string, required) must be in [SemVer v2.0.0](http://semver.org/spec/v2.0.0.html) format and specifies the version of the OCF specification with which the container bundle complies. The Open Container spec follows semantic versioning and retains forward and backward compatibility within major versions. For example, if an implementation is compliant with version 1.0.1 of the spec, it is compatible with the complete 1.x series.
+
+*Example*
+
+```json
+    "version": "0.1.0"
+```
+
+## Root Configuration
+
+Each container has exactly one *root filesystem*, specified in the *root* object:
+
+* **`path`** (string, required) Specifies the path to the root filesystem for the container, relative to the path where the manifest is. A directory MUST exist at the relative path declared by the field.
+* **`readonly`** (bool, optional) If true then the root filesystem MUST be read-only inside the container. Defaults to false.
+
+*Example*
+
+```json
+"root": {
+    "path": "rootfs",
+    "readonly": true
+}
+```
+
+## Mount Points
+
+You can add array of mount points inside container as `mounts`.
+Each record in this array must have configuration in [runtime config](runtime-config.md#mount-configuration).
+The runtime MUST mount entries in the listed order.
+
+* **`name`** (string, required) Name of mount point. Used for config lookup.
+* **`path`** (string, required) Destination of mount point: path inside container.
+
+*Example*
+
+```json
+"mounts": [
+    {
+        "name": "proc",
+        "path": "/proc"
+    },
+    {
+        "name": "dev",
+        "path": "/dev"
+    },
+    {
+        "name": "devpts",
+        "path": "/dev/pts"
+    },
+    {
+        "name": "data",
+        "path": "/data"
+    }
+]
+```
+
+## Process configuration
+
+* **`terminal`** (bool, optional) specifies whether you want a terminal attached to that process. Defaults to false.
+* **`cwd`** (string, optional) is the working directory that will be set for the executable.
+* **`env`** (array of strings, optional) contains a list of variables that will be set in the process's environment prior to execution. Elements in the array are specified as Strings in the form "KEY=value". The left hand side must consist solely of letters, digits, and underscores `_` as outlined in [IEEE Std 1003.1-2001](http://pubs.opengroup.org/onlinepubs/009695399/basedefs/xbd_chap08.html).
+* **`args`** (string, required) executable to launch and any flags as an array. The executable is the first element and must be available at the given path inside of the rootfs. If the executable path is not an absolute path then the search $PATH is interpreted to find the executable.
+
+The user for the process is a platform-specific structure that allows specific control over which user the process runs as.
+For Linux-based systems the user structure has the following fields:
+
+* **`uid`** (int, required) specifies the user id.
+* **`gid`** (int, required) specifies the group id.
+* **`additionalGids`** (array of ints, optional) specifies additional group ids to be added to the process.
+
+*Example (Linux)*
+
+```json
+"process": {
+    "terminal": true,
+    "user": {
+        "uid": 1,
+        "gid": 1,
+        "additionalGids": [5, 6]
+    },
+    "env": [
+        "PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin",
+        "TERM=xterm"
+    ],
+    "cwd": "/root",
+    "args": [
+        "sh"
+    ]
+}
+```
+
+
+## Hostname
+
+* **`hostname`** (string, optional) as it is accessible to processes running inside.  On Linux, you can only set this if your bundle creates a new [UTS namespace][uts-namespace].
+
+*Example*
+
+```json
+"hostname": "mrsdalloway"
+```
+
+## Platform-specific configuration
+
+* **`os`** (string, required) specifies the operating system family this image must run on. Values for os must be in the list specified by the Go Language document for [`$GOOS`](https://golang.org/doc/install/source#environment).
+* **`arch`** (string, required) specifies the instruction set for which the binaries in the image have been compiled. Values for arch must be in the list specified by the Go Language document for [`$GOARCH`](https://golang.org/doc/install/source#environment).
+
+```json
+"platform": {
+    "os": "linux",
+    "arch": "amd64"
+}
+```
+
+Interpretation of the platform section of the JSON file is used to find which platform-specific sections may be available in the document.
+For example, if `os` is set to `linux`, then a JSON object conforming to the [Linux-specific schema](config-linux.md) SHOULD be found at the key `linux` in the `config.json`.
+
+[uts-namespace]: http://man7.org/linux/man-pages/man7/namespaces.7.html

--- a/_includes/implementations.md
+++ b/_includes/implementations.md
@@ -1,0 +1,21 @@
+# Implementations
+
+The following sections link to associated projects, some of which are maintained by the OCI and some of which are maintained by external organizations.
+If you know of any associated projects that are not listed here, please file a pull request adding a link to that project.
+
+## Runtime (Container)
+
+* [opencontainers/runc](https://github.com/opencontainers/runc) - Reference implementation of OCI runtime
+
+## Runtime (Virtual Machine)
+
+* [hyperhq/runv](https://github.com/hyperhq/runv) - Hypervisor-based runtime for OCI
+
+## Bundle authoring
+
+* [kunalkushwaha/octool](https://github.com/kunalkushwaha/octool) - A config linter and validator.
+* [mrunalp/ocitools](https://github.com/mrunalp/ocitools) - A config generator.
+
+## Testing
+
+* [huawei-openlab/oct](https://github.com/huawei-openlab/oct) - Open Container Testing framework for OCI configuration and runtime

--- a/_includes/principles.md
+++ b/_includes/principles.md
@@ -1,0 +1,46 @@
+# The 5 principles of Standard Containers
+
+Define a unit of software delivery called a Standard Container.
+The goal of a Standard Container is to encapsulate a software component and all its dependencies in a format that is self-describing and portable, so that any compliant runtime can run it without extra dependencies, regardless of the underlying machine and the contents of the container.
+
+The specification for Standard Containers defines:
+
+1. configuration file formats
+2. a set of standard operations
+3. an execution environment.
+
+A great analogy for this is the physical shipping container used by the transportation industry.
+Shipping containers are a fundamental unit of delivery, they can be lifted, stacked, locked, loaded, unloaded and labelled.
+Irrespective of their contents, by standardizing the container itself it allowed for a consistent, more streamlined and efficient set of processes to be defined.
+For software Standard Containers offer similar functionality by being the fundamental, standardized, unit of delivery for a software package.
+
+## 1. Standard operations
+
+Standard Containers define a set of STANDARD OPERATIONS.
+They can be created, started, and stopped using standard container tools; copied and snapshotted using standard filesystem tools; and downloaded and uploaded using standard network tools.
+
+## 2. Content-agnostic
+
+Standard Containers are CONTENT-AGNOSTIC: all standard operations have the same effect regardless of the contents.
+They are started in the same way whether they contain a postgres database, a php application with its dependencies and application server, or Java build artifacts.
+
+## 3. Infrastructure-agnostic
+
+Standard Containers are INFRASTRUCTURE-AGNOSTIC: they can be run in any OCI supported infrastructure.
+For example, a standard container can be bundled on a laptop, uploaded to cloud storage, downloaded, run and snapshotted by a build server at a fiber hotel in Virginia, uploaded to 10 staging servers in a home-made private cloud cluster, then sent to 30 production instances across 3 public cloud regions.
+
+## 4. Designed for automation
+
+Standard Containers are DESIGNED FOR AUTOMATION: because they offer the same standard operations regardless of content and infrastructure, Standard Containers, are extremely well-suited for automation.
+In fact, you could say automation is their secret weapon.
+
+Many things that once required time-consuming and error-prone human effort can now be programmed.
+Before Standard Containers, by the time a software component ran in production, it had been individually built, configured, bundled, documented, patched, vendored, templated, tweaked and instrumented by 10 different people on 10 different computers.
+Builds failed, libraries conflicted, mirrors crashed, post-it notes were lost, logs were misplaced, cluster updates were half-broken.
+The process was slow, inefficient and cost a fortune - and was entirely different depending on the language and infrastructure provider.
+
+## 5. Industrial-grade delivery
+
+Standard Containers make INDUSTRIAL-GRADE DELIVERY of software a reality.
+Leveraging all of the properties listed above, Standard Containers are enabling large and small enterprises to streamline and automate their software delivery pipelines.
+Whether it is in-house devOps flows, or external customer-based software delivery mechanisms, Standard Containers are changing the way the community thinks about software packaging and delivery.

--- a/_includes/runtime-config-linux.md
+++ b/_includes/runtime-config-linux.md
@@ -1,0 +1,502 @@
+# Linux-specific Runtime Configuration
+
+## Namespaces
+
+A namespace wraps a global system resource in an abstraction that makes it appear to the processes within the namespace that they have their own isolated instance of the global resource.
+Changes to the global resource are visible to other processes that are members of the namespace, but are invisible to other processes.
+For more information, see [the man page](http://man7.org/linux/man-pages/man7/namespaces.7.html).
+
+Namespaces are specified as an array of entries inside the `namespaces` root field.
+The following parameters can be specified to setup namespaces:
+
+* **`type`** *(string, required)* - namespace type. The following namespaces types are supported:
+    * **`pid`** processes inside the container will only be able to see other processes inside the same container
+    * **`network`** the container will have its own network stack
+    * **`mount`** the container will have an isolated mount table
+    * **`ipc`** processes inside the container will only be able to communicate to other processes inside the same container via system level IPC
+    * **`uts`** the container will be able to have its own hostname and domain name
+    * **`user`** the container will be able to remap user and group IDs from the host to local users and groups within the container
+
+* **`path`** *(string, optional)* - path to namespace file
+
+If a path is specified, that particular file is used to join that type of namespace.
+Also, when a path is specified, a runtime MUST assume that the setup for that particular namespace has already been done and error out if the config specifies anything else related to that namespace.
+
+###### Example
+
+```json
+    "namespaces": [
+        {
+            "type": "pid",
+            "path": "/proc/1234/ns/pid"
+        },
+        {
+            "type": "network",
+            "path": "/var/run/netns/neta"
+        },
+        {
+            "type": "mount"
+        },
+        {
+            "type": "ipc"
+        },
+        {
+            "type": "uts"
+        },
+        {
+            "type": "user"
+        }
+    ]
+```
+
+## Devices
+
+`devices` is an array specifying the list of devices to be created in the container.
+
+The following parameters can be specified:
+
+* **`type`** *(char, required)* - type of device: `c`, `b`, `u` or `p`. More info in `man mknod`.
+
+* **`path`** *(string, optional)* - full path to device inside container
+
+* **`major, minor`** *(int64, required)* - major, minor numbers for device. More info in `man mknod`. There is a special value: `-1`, which means `*` for `device` cgroup setup.
+
+* **`permissions`** *(string, optional)* - cgroup permissions for device. A composition of `r` (*read*), `w` (*write*), and `m` (*mknod*).
+
+* **`fileMode`** *(uint32, optional)* - file mode for device file
+
+* **`uid`** *(uint32, optional)* - uid of device owner
+
+* **`gid`** *(uint32, optional)* - gid of device owner
+
+**`fileMode`**, **`uid`** and **`gid`** are required if **`path`** is given and are otherwise not allowed.
+
+###### Example
+
+```json
+   "devices": [
+        {
+            "path": "/dev/random",
+            "type": "c",
+            "major": 1,
+            "minor": 8,
+            "permissions": "rwm",
+            "fileMode": 0666,
+            "uid": 0,
+            "gid": 0
+        },
+        {
+            "path": "/dev/urandom",
+            "type": "c",
+            "major": 1,
+            "minor": 9,
+            "permissions": "rwm",
+            "fileMode": 0666,
+            "uid": 0,
+            "gid": 0
+        },
+        {
+            "path": "/dev/null",
+            "type": "c",
+            "major": 1,
+            "minor": 3,
+            "permissions": "rwm",
+            "fileMode": 0666,
+            "uid": 0,
+            "gid": 0
+        },
+        {
+            "path": "/dev/zero",
+            "type": "c",
+            "major": 1,
+            "minor": 5,
+            "permissions": "rwm",
+            "fileMode": 0666,
+            "uid": 0,
+            "gid": 0
+        },
+        {
+            "path": "/dev/tty",
+            "type": "c",
+            "major": 5,
+            "minor": 0,
+            "permissions": "rwm",
+            "fileMode": 0666,
+            "uid": 0,
+            "gid": 0
+        },
+        {
+            "path": "/dev/full",
+            "type": "c",
+            "major": 1,
+            "minor": 7,
+            "permissions": "rwm",
+            "fileMode": 0666,
+            "uid": 0,
+            "gid": 0
+        }
+    ]
+```
+
+## Control groups
+
+Also known as cgroups, they are used to restrict resource usage for a container and handle device access.
+cgroups provide controls to restrict cpu, memory, IO, pids and network for the container.
+For more information, see the [kernel cgroups documentation](https://www.kernel.org/doc/Documentation/cgroups/cgroups.txt).
+
+The path to the cgroups can be specified in the Spec via `cgroupsPath`.
+`cgroupsPath` is expected to be relative to the cgroups mount point.
+If not specified, cgroups will be created under '/'.
+Implementations of the Spec can choose to name cgroups in any manner.
+The Spec does not include naming schema for cgroups.
+The Spec does not support [split hierarchy](https://www.kernel.org/doc/Documentation/cgroups/unified-hierarchy.txt).
+The cgroups will be created if they don't exist.
+
+```json
+   "cgroupsPath": "/myRuntime/myContainer"
+```
+
+`cgroupsPath` can be used to either control the cgroups hierarchy for containers or to run a new process in an existing container.
+
+You can configure a container's cgroups via the `resources` field of the Linux configuration.
+Do not specify `resources` unless limits have to be updated.
+For example, to run a new process in an existing container without updating limits, `resources` need not be specified.
+
+#### Disable out-of-memory killer
+
+`disableOOMKiller` contains a boolean (`true` or `false`) that enables or disables the Out of Memory killer for a cgroup.
+If enabled (`false`), tasks that attempt to consume more memory than they are allowed are immediately killed by the OOM killer.
+The OOM killer is enabled by default in every cgroup using the `memory` subsystem.
+To disable it, specify a value of `true`.
+For more information, see [the memory cgroup man page](https://www.kernel.org/doc/Documentation/cgroups/memory.txt).
+
+* **`disableOOMKiller`** *(bool, optional)* - enables or disables the OOM killer
+
+###### Example
+
+```json
+    "disableOOMKiller": false
+```
+
+#### Set oom_score_adj
+
+More information on `oom_score_adj` available [here](https://www.kernel.org/doc/Documentation/filesystems/proc.txt).
+
+```json
+    "oomScoreAdj": 0
+```
+
+#### Memory
+
+`memory` represents the cgroup subsystem `memory` and it's used to set limits on the container's memory usage.
+For more information, see [the memory cgroup man page](https://www.kernel.org/doc/Documentation/cgroups/memory.txt).
+
+The following parameters can be specified to setup the controller:
+
+* **`limit`** *(uint64, optional)* - sets limit of memory usage
+
+* **`reservation`** *(uint64, optional)* - sets soft limit of memory usage
+
+* **`swap`** *(uint64, optional)* - sets limit of memory+Swap usage
+
+* **`kernel`** *(uint64, optional)* - sets hard limit for kernel memory
+
+* **`swappiness`** *(uint64, optional)* - sets swappiness parameter of vmscan (See sysctl's vm.swappiness)
+
+###### Example
+
+```json
+    "memory": {
+        "limit": 0,
+        "reservation": 0,
+        "swap": 0,
+        "kernel": 0,
+        "swappiness": -1
+    }
+```
+
+#### CPU
+
+`cpu` represents the cgroup subsystems `cpu` and `cpusets`.
+For more information, see [the cpusets cgroup man page](https://www.kernel.org/doc/Documentation/cgroups/cpusets.txt).
+
+The following parameters can be specified to setup the controller:
+
+* **`shares`** *(uint64, optional)* - specifies a relative share of CPU time available to the tasks in a cgroup
+
+* **`quota`** *(uint64, optional)* - specifies the total amount of time in microseconds for which all tasks in a cgroup can run during one period (as defined by **`period`** below)
+
+* **`period`** *(uint64, optional)* - specifies a period of time in microseconds for how regularly a cgroup's access to CPU resources should be reallocated (CFS scheduler only)
+
+* **`realtimeRuntime`** *(uint64, optional)* - specifies a period of time in microseconds for the longest continuous period in which the tasks in a cgroup have access to CPU resources
+
+* **`realtimePeriod`** *(uint64, optional)* - same as **`period`** but applies to realtime scheduler only
+
+* **`cpus`** *(string, optional)* - list of CPUs the container will run in
+
+* **`mems`** *(string, optional)* - list of Memory Nodes the container will run in
+
+###### Example
+
+```json
+    "cpu": {
+        "shares": 0,
+        "quota": 0,
+        "period": 0,
+        "realtimeRuntime": 0,
+        "realtimePeriod": 0,
+        "cpus": "",
+        "mems": ""
+    }
+```
+
+#### Block IO Controller
+
+`blockIO` represents the cgroup subsystem `blkio` which implements the block io controller.
+For more information, see [the kernel cgroups documentation about blkio](https://www.kernel.org/doc/Documentation/cgroups/blkio-controller.txt).
+
+The following parameters can be specified to setup the controller:
+
+* **`blkioWeight`** *(uint16, optional)* - specifies per-cgroup weight. This is default weight of the group on all devices until and unless overridden by per-device rules. The range is from 10 to 1000.
+
+* **`blkioLeafWeight`** *(uint16, optional)* - equivalents of `blkioWeight` for the purpose of deciding how much weight tasks in the given cgroup has while competing with the cgroup's child cgroups. The range is from 10 to 1000.
+
+* **`blkioWeightDevice`** *(array, optional)* - specifies the list of devices which will be bandwidth rate limited. The following parameters can be specified per-device:
+    * **`major, minor`** *(int64, required)* - major, minor numbers for device. More info in `man mknod`.
+    * **`weight`** *(uint16, optional)* - bandwidth rate for the device, range is from 10 to 1000
+    * **`leafWeight`** *(uint16, optional)* - bandwidth rate for the device while competing with the cgroup's child cgroups, range is from 10 to 1000, CFQ scheduler only
+
+    You must specify at least one of `weight` or `leafWeight` in a given entry, and can specify both.
+
+* **`blkioThrottleReadBpsDevice`**, **`blkioThrottleWriteBpsDevice`**, **`blkioThrottleReadIOPSDevice`**, **`blkioThrottleWriteIOPSDevice`** *(array, optional)* - specify the list of devices which will be IO rate limited. The following parameters can be specified per-device:
+    * **`major, minor`** *(int64, required)* - major, minor numbers for device. More info in `man mknod`.
+    * **`rate`** *(uint64, required)* - IO rate limit for the device
+
+###### Example
+
+```json
+    "blockIO": {
+        "blkioWeight": 0,
+        "blkioLeafWeight": 0,
+        "blkioWeightDevice": [
+            {
+                "major": 8,
+                "minor": 0,
+                "weight": 500,
+                "leafWeight": 300
+            },
+            {
+                "major": 8,
+                "minor": 16,
+                "weight": 500
+            }
+        ],
+        "blkioThrottleReadBpsDevice": [
+            {
+                "major": 8,
+                "minor": 0,
+                "rate": 600
+            }
+        ],
+        "blkioThrottleWriteIOPSDevice": [
+            {
+                "major": 8,
+                "minor": 16,
+                "rate": 300
+            }
+        ]
+    }
+```
+
+#### Huge page limits
+
+`hugepageLimits` represents the `hugetlb` controller which allows to limit the
+HugeTLB usage per control group and enforces the controller limit during page fault.
+For more information, see the [kernel cgroups documentation about HugeTLB](https://www.kernel.org/doc/Documentation/cgroups/hugetlb.txt).
+
+`hugepageLimits` is an array of entries, each having the following structure:
+
+* **`pageSize`** *(string, required)* - hugepage size
+
+* **`limit`** *(uint64, required)* - limit in bytes of *hugepagesize* HugeTLB usage
+
+###### Example
+
+```json
+   "hugepageLimits": [
+        {
+            "pageSize": "2MB",
+            "limit": 9223372036854771712
+        }
+   ]
+```
+
+#### Network
+
+`network` represents the cgroup subsystems `net_cls` and `net_prio`.
+For more information, see [the net\_cls cgroup man page](https://www.kernel.org/doc/Documentation/cgroups/net_cls.txt) and [the net\_prio cgroup man page](https://www.kernel.org/doc/Documentation/cgroups/net_prio.txt).
+
+The following parameters can be specified to setup these cgroup controllers:
+
+* **`classID`** *(string, optional)* - is the network class identifier the cgroup's network packets will be tagged with
+
+* **`priorities`** *(array, optional)* - specifies a list of objects of the priorities assigned to traffic originating from
+processes in the group and egressing the system on various interfaces. The following parameters can be specified per-priority:
+    * **`name`** *(string, required)* - interface name
+    * **`priority`** *(uint32, required)* - priority applied to the interface
+
+###### Example
+
+```json
+   "network": {
+        "classID": "0x100001",
+        "priorities": [
+            {
+                "name": "eth0",
+                "priority": 500
+            },
+            {
+                "name": "eth1",
+                "priority": 1000
+            }
+        ]
+   }
+```
+
+#### PIDs
+
+`pids` represents the cgroup subsystem `pids`.
+For more information, see [the pids cgroup man page](https://www.kernel.org/doc/Documentation/cgroups/pids.txt
+).
+
+The following paramters can be specified to setup the controller:
+
+* **`limit`** *(int64, required)* - specifies the maximum number of tasks in the cgroup
+
+###### Example
+
+```json
+   "pids": {
+        "limit": 32771
+   }
+```
+
+## Sysctl
+
+sysctl allows kernel parameters to be modified at runtime for the container.
+For more information, see [the man page](http://man7.org/linux/man-pages/man8/sysctl.8.html)
+
+###### Example
+
+```json
+   "sysctl": {
+        "net.ipv4.ip_forward": "1",
+        "net.core.somaxconn": "256"
+   }
+```
+
+## Rlimits
+
+rlimits allow setting resource limits.
+`type` is a string with a value from those defined in [the man page](http://man7.org/linux/man-pages/man2/setrlimit.2.html).
+The kernel enforces the `soft` limit for a resource while the `hard` limit acts as a ceiling for that value that could be set by an unprivileged process.
+
+###### Example
+
+```json
+   "rlimits": [
+        {
+            "type": "RLIMIT_NPROC",
+            "soft": 1024,
+            "hard": 102400
+        }
+   ]
+```
+
+## SELinux process label
+
+SELinux process label specifies the label with which the processes in a container are run.
+For more information about SELinux, see  [Selinux documentation](http://selinuxproject.org/page/Main_Page)
+
+###### Example
+
+```json
+   "selinuxProcessLabel": "system_u:system_r:svirt_lxc_net_t:s0:c124,c675"
+```
+
+## Apparmor profile
+
+Apparmor profile specifies the name of the apparmor profile that will be used for the container.
+For more information about Apparmor, see [Apparmor documentation](https://wiki.ubuntu.com/AppArmor)
+
+###### Example
+
+```json
+   "apparmorProfile": "acme_secure_profile"
+```
+
+## seccomp
+
+Seccomp provides application sandboxing mechanism in the Linux kernel.
+Seccomp configuration allows one to configure actions to take for matched syscalls and furthermore also allows matching on values passed as arguments to syscalls.
+For more information about Seccomp, see [Seccomp kernel documentation](https://www.kernel.org/doc/Documentation/prctl/seccomp_filter.txt)
+The actions, architectures, and operators are strings that match the definitions in seccomp.h from [libseccomp](https://github.com/seccomp/libseccomp) and are translated to corresponding values.
+A valid list of constants as of Libseccomp v2.2.3 is contained below.
+
+Architecture Constants
+* `SCMP_ARCH_X86`
+* `SCMP_ARCH_X86_64`
+* `SCMP_ARCH_X32`
+* `SCMP_ARCH_ARM`
+* `SCMP_ARCH_AARCH64`
+* `SCMP_ARCH_MIPS`
+* `SCMP_ARCH_MIPS64`
+* `SCMP_ARCH_MIPS64N32`
+* `SCMP_ARCH_MIPSEL`
+* `SCMP_ARCH_MIPSEL64`
+* `SCMP_ARCH_MIPSEL64N32`
+
+Action Constants:
+* `SCMP_ACT_KILL`
+* `SCMP_ACT_TRAP`
+* `SCMP_ACT_ERRNO`
+* `SCMP_ACT_TRACE`
+* `SCMP_ACT_ALLOW`
+
+Operator Constants:
+* `SCMP_CMP_NE`
+* `SCMP_CMP_LT`
+* `SCMP_CMP_LE`
+* `SCMP_CMP_EQ`
+* `SCMP_CMP_GE`
+* `SCMP_CMP_GT`
+* `SCMP_CMP_MASKED_EQ`
+
+###### Example
+
+```json
+   "seccomp": {
+       "defaultAction": "SCMP_ACT_ALLOW",
+       "architectures": [
+           "SCMP_ARCH_X86"
+       ],
+       "syscalls": [
+           {
+               "name": "getcwd",
+               "action": "SCMP_ACT_ERRNO"
+           }
+       ]
+   }
+```
+
+## Rootfs Mount Propagation
+
+rootfsPropagation sets the rootfs's mount propagation.
+Its value is either slave, private, or shared.
+[The kernel doc](https://www.kernel.org/doc/Documentation/filesystems/sharedsubtree.txt) has more information about mount propagation.
+
+###### Example
+
+```json
+    "rootfsPropagation": "slave",
+```

--- a/_includes/runtime-config.md
+++ b/_includes/runtime-config.md
@@ -1,0 +1,121 @@
+# Runtime Configuration
+
+## Hooks
+
+Lifecycle hooks allow custom events for different points in a container's runtime.
+Presently there are `Prestart`, `Poststart` and `Poststop`.
+
+* [`Prestart`](#prestart) is a list of hooks to be run before the container process is executed
+* [`Poststart`](#poststart) is a list of hooks to be run immediately after the container process is started
+* [`Poststop`](#poststop) is a list of hooks to be run after the container process exits
+
+Hooks allow one to run code before/after various lifecycle events of the container.
+Hooks MUST be called in the listed order.
+The state of the container is passed to the hooks over stdin, so the hooks could get the information they need to do their work.
+
+Hook paths are absolute and are executed from the host's filesystem.
+
+### Prestart
+
+The pre-start hooks are called after the container process is spawned, but before the user supplied command is executed.
+They are called after the container namespaces are created on Linux, so they provide an opportunity to customize the container.
+In Linux, for e.g., the network namespace could be configured in this hook.
+
+If a hook returns a non-zero exit code, then an error including the exit code and the stderr is returned to the caller and the container is torn down.
+
+### Poststart
+
+The post-start hooks are called after the user process is started.
+For example this hook can notify user that real process is spawned.
+
+If a hook returns a non-zero exit code, then an error is logged and the remaining hooks are executed.
+
+### Poststop
+
+The post-stop hooks are called after the container process is stopped.
+Cleanup or debugging could be performed in such a hook.
+If a hook returns a non-zero exit code, then an error is logged and the remaining hooks are executed.
+
+*Example*
+
+```json
+    "hooks" : {
+        "prestart": [
+            {
+                "path": "/usr/bin/fix-mounts",
+                "args": ["arg1", "arg2"],
+                "env":  [ "key1=value1"]
+            },
+            {
+                "path": "/usr/bin/setup-network"
+            }
+        ],
+        "poststart": [
+            {
+                "path": "/usr/bin/notify-start"
+            }
+        ],
+        "poststop": [
+            {
+                "path": "/usr/sbin/cleanup.sh",
+                "args": ["-f"]
+            }
+        ]
+    }
+```
+
+`path` is required for a hook.
+`args` and `env` are optional.
+
+## Mount Configuration
+
+Additional filesystems can be declared as "mounts", specified in the *mounts* object.
+Keys in this object are names of mount points from portable config.
+Values are objects with configuration of mount points.
+The parameters are similar to the ones in [the Linux mount system call](http://man7.org/linux/man-pages/man2/mount.2.html).
+Only [mounts from the portable config](config.md#mount-points) will be mounted.
+
+* **`type`** (string, required) Linux, *filesystemtype* argument supported by the kernel are listed in */proc/filesystems* (e.g., "minix", "ext2", "ext3", "jfs", "xfs", "reiserfs", "msdos", "proc", "nfs", "iso9660"). Windows: ntfs
+* **`source`** (string, required) a device name, but can also be a directory name or a dummy. Windows, the volume name that is the target of the mount point. \\?\Volume\{GUID}\ (on Windows source is called target)
+* **`options`** (list of strings, optional) in the fstab format [https://wiki.archlinux.org/index.php/Fstab](https://wiki.archlinux.org/index.php/Fstab).
+
+*Example (Linux)*
+
+```json
+"mounts": {
+    "proc": {
+        "type": "proc",
+        "source": "proc",
+        "options": []
+    },
+    "dev": {
+        "type": "tmpfs",
+        "source": "tmpfs",
+        "options": ["nosuid","strictatime","mode=755","size=65536k"]
+    },
+    "devpts": {
+        "type": "devpts",
+        "source": "devpts",
+        "options": ["nosuid","noexec","newinstance","ptmxmode=0666","mode=0620","gid=5"]
+    },
+    "data": {
+        "type": "bind",
+        "source": "/volumes/testing",
+        "options": ["rbind","rw"]
+    }
+}
+```
+
+*Example (Windows)*
+
+```json
+"mounts": {
+    "myfancymountpoint": {
+        "type": "ntfs",
+        "source": "\\\\?\\Volume\\{2eca078d-5cbc-43d3-aff8-7e8511f60d0e}\\",
+        "options": []
+    }
+}
+```
+
+See links for details about [mountvol](http://ss64.com/nt/mountvol.html) and [SetVolumeMountPoint](https://msdn.microsoft.com/en-us/library/windows/desktop/aa365561(v=vs.85).aspx) in Windows.

--- a/_includes/runtime-linux.md
+++ b/_includes/runtime-linux.md
@@ -1,0 +1,8 @@
+# Linux Runtime
+
+## File descriptors
+By default, only the `stdin`, `stdout` and `stderr` file descriptors are kept open for the application by the runtime.
+
+The runtime may pass additional file descriptors to the application to support features such as [socket activation](http://0pointer.de/blog/projects/socket-activated-containers.html).
+
+Some of the file descriptors may be redirected to `/dev/null` even though they are open.

--- a/_includes/runtime.md
+++ b/_includes/runtime.md
@@ -1,0 +1,57 @@
+# Runtime and Lifecycle
+
+## State
+
+Runtime MUST store container metadata on disk so that external tools can consume and act on this information.
+It is recommended that this data be stored in a temporary filesystem so that it can be removed on a system reboot.
+On Linux/Unix based systems the metadata MUST be stored under `/run/opencontainer/containers`.
+For non-Linux/Unix based systems the location of the root metadata directory is currently undefined.
+Within that directory there MUST be one directory for each container created, where the name of the directory MUST be the ID of the container.
+For example: for a Linux container with an ID of `173975398351`, there will be a corresponding directory: `/run/opencontainer/containers/173975398351`.
+Within each container's directory, there MUST be a JSON encoded file called `state.json` that contains the runtime state of the container.
+For example: `/run/opencontainer/containers/173975398351/state.json`.
+
+The `state.json` file MUST contain all of the following properties:
+
+* **`version`**: (string) is the OCF specification version used when creating the container.
+* **`id`**: (string) is the container's ID.
+This MUST be unique across all containers on this host.
+There is no requirement that it be unique across hosts.
+The ID is provided in the state because hooks will be executed with the state as the payload.
+This allows the hooks to perform cleanup and teardown logic after the runtime destroys its own state.
+* **`pid`**: (int) is the ID of the main process within the container, as seen by the host.
+* **`bundlePath`**: (string) is the absolute path to the container's bundle directory.
+This is provided so that consumers can find the container's configuration and root filesystem on the host.
+
+*Example*
+
+```json
+{
+    "version": "0.2.0",
+    "id": "oc-container",
+    "pid": 4422,
+    "root": "/containers/redis"
+}
+```
+
+## Lifecycle
+
+### Create
+
+Creates the container: file system, namespaces, cgroups, capabilities.
+
+### Start (process)
+
+Runs a process in a container.
+Can be invoked several times.
+
+### Stop (process)
+
+Not sure we need that from runc cli.
+Process is killed from the outside.
+
+This event needs to be captured by runc to run onstop event handlers.
+
+## Hooks
+
+See [runtime configuration for hooks](./runtime-config.md)

--- a/index.md
+++ b/index.md
@@ -1,0 +1,15 @@
+---
+title: single-page specification
+---
+{% include README.md %}
+{% include code-of-conduct.md %}
+{% include principles.md %}
+{% include ROADMAP.md %}
+{% include implementations.md %}
+{% include bundle.md %}
+{% include runtime.md %}
+{% include runtime-linux.md %}
+{% include config.md %}
+{% include config-linux.md %}
+{% include runtime-config.md %}
+{% include runtime-config-linux.md %}


### PR DESCRIPTION
As an alternative to #263.  Example HTML currently [here][1], and it's
not especially beautiful (e.g. it has the same “[links point out of
the file][2]” issue.  But we can fix/mitigate some of those issues
with Makefile rules and a gh-pages release build.  The pandoc/LaTeX
approach from #263 could fix link targets with similar Makefile rules,
so I think it's a wash there.  But this approach seems better to me
because “push to gh-pages” is a smaller barrier-to-entry than “install
this pandoc/LaTeX docker image”.

The _includes directory holds copies of files to avoid:

    A file was included in index.md that is a symlink or does not exist
    in your _includes directory. For more information, see
    https://help.github.com/articles/page-build-failed-file-is-a-symlink.

[1]: https://wking.github.io/opencontainer-specs/
[2]: https://github.com/opencontainers/specs/pull/263#issuecomment-163341758