### PR TITLE
runtime-config: Require serial hook execution

### DIFF
--- a/runtime-config.md
+++ b/runtime-config.md
@@ -10,7 +10,7 @@ Presently there are `Prestart`, `Poststart` and `Poststop`.
 * [`Poststop`](#poststop) is a list of hooks to be run after the container process exits
 
 Hooks allow one to run code before/after various lifecycle events of the container.
-Hooks MUST be called in the listed order.
+Hooks MUST be called in the listed order, with each hook process being reaped before the next hook is executed.
 The state of the container is passed to the hooks over stdin, so the hooks could get the information they need to do their work.
 
 Hook paths are absolute and are executed from the host's filesystem.


### PR DESCRIPTION
Extend #157 to avoid:

    hook 1: spawn ---------------> reaped
    hook 2:       spawn ----------------> reaped
    hook 3:             spawn -----> reaped

and explicitly require:

    hook 1: spawn --> reaped
    hook 2:                  spawn --> reaped
    hook 3:                                   spawn --> reaped

Folks who do want parallel execution are free to use a parallelizing
wrapper:

    hook 1: spawn ---------------------------> reaped
                  child 1 -----> reaped
                    child 2 ---------> reaped
                      child 3 ---> reaped

Although that cuts both ways (with parallel hooks, folks could always
use a single hook with a serializing wrapper).  Still, I'd guess most
current implementations are already taking the serialized approach, so
it makes bundle-author life easier if we are explicit about that.