### PR TITLE
lifecycle: Mention runtime.json

### DIFF
--- a/runtime.md
+++ b/runtime.md
@@ -38,8 +38,8 @@ This is provided so that consumers can find the container's configuration and ro
 The lifecycle describes the timeline of events that happen from when a container is created to when it ceases to exist.
 
 1. OCI compliant runtime is invoked by passing the bundle path as argument.
-2. The container's runtime environment is created according to the configuration in config.json.
-   Any updates to config.json after container is running do not affect the container.
+2. The container's runtime environment is created according to the configuration in `config.json` and `runtime.json`.
+   Any updates to `config.json` or `runtime.json` after container is running do not affect the container.
 3. The container's state.json file is written to the filesystem.
 4. The prestart hooks are invoked by the runtime.
    If any prestart hook fails, then the container is stopped and the lifecycle continues at step 8.


### PR DESCRIPTION
As [discussed][1] [in][2] #231.  I'm in favor of [rolling it back into
`config.json`][3], but we [aren't there yet][4].  I also added
backticks around the filenames for consistency with bundle.md.

This seemed uncontroversial enough to go straight to a PR (and not via
a mailing list thread), but I'm happy to spin up a mailing list thread
around it if anyone thinks I'm overlooking a contentious issue.

[1]: https://github.com/opencontainers/specs/pull/231#discussion_r43262848
[2]: https://github.com/opencontainers/specs/pull/231/files#r46735828
[3]: https://groups.google.com/a/opencontainers.org/forum/#!topic/dev/0QbyJDM9fWY
[4]: https://github.com/opencontainers/specs/blob/4a63e81a807edec3d67ed2b6bd99a6c2b288676f/bundle.md#container-format