### PR TITLE
lifecycle: Don't require /run/opencontainer/<runtime>/containers

### DIFF
--- a/runtime.md
+++ b/runtime.md
@@ -40,7 +40,7 @@ The lifecycle describes the timeline of events that happen from when a container
 1. OCI compliant runtime is invoked by passing the bundle path as argument.
 2. The container's runtime environment is created according to the configuration in config.json.
    Any updates to config.json after container is running do not affect the container.
-3. The container's state.json file is written to the filesystem under /run/opencontainer/<runtime>/containers/<id>/.
+3. The container's state.json file is written to the filesystem.
 4. The prestart hooks are invoked by the runtime.
    If any prestart hook fails, then the container is stopped and the lifecycle continues at step 8.
 5. The user specified process is executed in the container.


### PR DESCRIPTION
As [discussed][0] in #231.  We [already require it for
Linux/Unix-based systems][1], so we don't have to repeat it here.  And
other systems will use different paths, which we haven't specified
yet.  When [I asked why we didn't specify a path for Windows][2],
[Vincent said we were waiting on help from PoC implementations][3].
So this commit punts the location to the “State” section, and lets the
“Lifecycle” section just focus on when the write-to-filesystem
happens.

There's also [discussion about removing the filesystem state registry
completely][4], in which case we'd want to remove the whole line from
the lifecycle.  If we expect to switch to something like [`--state
PATH`][5] in the near future this PR is just polishing dead
documentation.

[0]: https://github.com/opencontainers/specs/pull/231/files#r45532115
[1]: https://github.com/opencontainers/specs/commit/7713efc1be66dda08548ad12da6509fd93662308#diff-b84a8d65d8ed53f4794cd2db7e8ea731L7
[2]: https://github.com/opencontainers/specs/pull/211#discussion_r41066673
[3]: https://github.com/opencontainers/specs/pull/211#discussion_r41067134
[4]: https://groups.google.com/a/opencontainers.org/forum/#!topic/dev/q6TYqVZOcX8
[5]: https://groups.google.com/a/opencontainers.org/d/msg/dev/q6TYqVZOcX8/W1RVyCXCCQAJ