### PR TITLE
implementations: Reference the CNI as a Linux network hook

### DIFF
--- a/implementations.md
+++ b/implementations.md
@@ -19,3 +19,21 @@ If you know of any associated projects that are not listed here, please file a p
 ## Testing
 
 * [huawei-openlab/oct](https://github.com/huawei-openlab/oct) - Open Container Testing framework for OCI configuration and runtime
+
+## Hooks
+
+For addressing container issues that are outside the scope of this specification, the following hooks may be useful.
+
+### Linux
+
+#### Networking
+
+* [CNI][], the Container Network Interface.
+  The [`exec-plugins.sh`][cni-exec-plugins.sh] script can be used in both [prestart][] (with `add`) and [poststop][] (with `del`) hooks insert and remove a container from networks [configured][cni-conf] in a host-side directory like `/etc/cni/net.d`.
+
+[prestart]: runtime-config.md#prestart
+[poststop]: runtime-config.md#poststop
+
+[CNI]: https://github.com/appc/cni
+[cni-exec-plugins.sh]: https://github.com/appc/cni/blob/v0.1.0/scripts/exec-plugins.sh
+[cni-conf]: https://github.com/appc/cni/blob/v0.1.0/SPEC.md


### PR DESCRIPTION
Based on @philips' [post][1].  Container-ID injection would take a
wrapping shell instance or some such (e.g., see [here][2]), but I
imagine config authors can figure that out (or just write an
alternative wrapper script that extracts the container ID from stdin's
state JSON on its own).

[1]: https://groups.google.com/a/opencontainers.org/d/msg/dev/9VMBA2dAeuU/OGl8tsNBCwAJ
[2]: https://groups.google.com/a/opencontainers.org/d/msg/dev/9VMBA2dAeuU/LzELsZO-CgAJ