### PR TITLE
runtime_config_linux.go: add missing pointer

### DIFF
--- a/runtime_config_linux.go
+++ b/runtime_config_linux.go
@@ -127,7 +127,7 @@ type WeightDevice struct {
 type ThrottleDevice struct {
 	blockIODevice
 	// Rate is the IO rate limit per cgroup per device
-	Rate uint64 `json:"rate"`
+	Rate *uint64 `json:"rate,omitempty"`
 }
 
 // BlockIO for Linux cgroup 'blkio' resource management


### PR DESCRIPTION
/cc @vishh

Signed-off-by: Antonio Murdaca <runcom@redhat.com>