### PR TITLE
Fix value of swappiness

### DIFF
--- a/runtime-config-linux.md
+++ b/runtime-config-linux.md
@@ -214,7 +214,7 @@ The following parameters can be specified to setup the controller:
         "swap": 0,
         "kernel": 0,
         "kernelTCP": 0,
-        "swappiness": -1
+        "swappiness": 0
     }
 ```
 


### PR DESCRIPTION
It's officially pointer of uint64 now, no point it can be
-1, change it to 0 as other fields in example.

Signed-off-by: Qiang Huang <h.huangqiang@huawei.com>