### PR TITLE
Appropriately mark optional fields as omitempty

### DIFF
--- a/config.go
+++ b/config.go
@@ -13,7 +13,7 @@ type Spec struct {
 	// Root is the root information for the container's filesystem.
 	Root Root `json:"root"`
 	// Hostname is the container's host name.
-	Hostname string `json:"hostname"`
+	Hostname string `json:"hostname,omitempty"`
 	// Mounts profile configuration for adding mounts to the container's filesystem.
 	Mounts []MountPoint `json:"mounts"`
 }
@@ -27,10 +27,10 @@ type Process struct {
 	// Args specifies the binary and arguments for the application to execute.
 	Args []string `json:"args"`
 	// Env populates the process environment for the process.
-	Env []string `json:"env"`
+	Env []string `json:"env,omitempty"`
 	// Cwd is the current working directory for the process and must be
 	// relative to the container's root.
-	Cwd string `json:"cwd"`
+	Cwd string `json:"cwd,omitempty"`
 }
 
 // Root contains information about the container's root filesystem on the host.

--- a/config_linux.go
+++ b/config_linux.go
@@ -21,5 +21,5 @@ type User struct {
 	// GID is the group id.
 	GID uint32 `json:"gid"`
 	// AdditionalGids are additional group ids set for the container's process.
-	AdditionalGids []uint32 `json:"additionalGids"`
+	AdditionalGids []uint32 `json:"additionalGids,omitempty"`
 }

--- a/runtime_config.go
+++ b/runtime_config.go
@@ -15,19 +15,19 @@ type RuntimeSpec struct {
 // Hook specifies a command that is run at a particular event in the lifecycle of a container
 type Hook struct {
 	Path string   `json:"path"`
-	Args []string `json:"args"`
-	Env  []string `json:"env"`
+	Args []string `json:"args,omitempty"`
+	Env  []string `json:"env,omitempty"`
 }
 
 // Hooks for container setup and teardown
 type Hooks struct {
 	// Prestart is a list of hooks to be run before the container process is executed.
 	// On Linux, they are run after the container namespaces are created.
-	Prestart []Hook `json:"prestart"`
+	Prestart []Hook `json:"prestart,omitempty"`
 	// Poststart is a list of hooks to be run after the container process is started.
-	Poststart []Hook `json:"poststart"`
+	Poststart []Hook `json:"poststart,omitempty"`
 	// Poststop is a list of hooks to be run after the container process exits.
-	Poststop []Hook `json:"poststop"`
+	Poststop []Hook `json:"poststop,omitempty"`
 }
 
 // Mount specifies a mount for a container
@@ -38,5 +38,5 @@ type Mount struct {
 	// linux based systems this would be the file on the host.
 	Source string `json:"source"`
 	// Options are fstab style mount options.
-	Options []string `json:"options"`
+	Options []string `json:"options,omitempty"`
 }

--- a/runtime_config_linux.go
+++ b/runtime_config_linux.go
@@ -15,13 +15,13 @@ type LinuxRuntimeSpec struct {
 // LinuxRuntime hosts the Linux-only runtime information
 type LinuxRuntime struct {
 	// UIDMapping specifies user mappings for supporting user namespaces on linux.
-	UIDMappings []IDMapping `json:"uidMappings"`
+	UIDMappings []IDMapping `json:"uidMappings,omitempty"`
 	// GIDMapping specifies group mappings for supporting user namespaces on linux.
-	GIDMappings []IDMapping `json:"gidMappings"`
+	GIDMappings []IDMapping `json:"gidMappings,omitempty"`
 	// Rlimits specifies rlimit options to apply to the container's process.
-	Rlimits []Rlimit `json:"rlimits"`
+	Rlimits []Rlimit `json:"rlimits,omitempty"`
 	// Sysctl are a set of key value pairs that are set for the container on start
-	Sysctl map[string]string `json:"sysctl"`
+	Sysctl map[string]string `json:"sysctl,omitempty"`
 	// Resources contain cgroup information for handling resource constraints
 	// for the container
 	Resources *Resources `json:"resources,omitempty"`
@@ -49,7 +49,7 @@ type Namespace struct {
 	Type NamespaceType `json:"type"`
 	// Path is a path to an existing namespace persisted on disk that can be joined
 	// and is of the same type
-	Path string `json:"path"`
+	Path string `json:"path,omitempty"`
 }
 
 // NamespaceType is one of the linux namespaces


### PR DESCRIPTION
`runc spec` creates files with plenty of empty arrays, `null` values, and empty strings. While I'm mostly concerned about the latter case (some parsers will consider `"" != undefined`), the rest is ugliness that could be done without anyway.