### PR TITLE
style: Collect established conventions in a discoverable location

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,6 +4,7 @@ DOC_FILES := \
 	README.md \
 	code-of-conduct.md \
 	principles.md \
+	style.md \
 	ROADMAP.md \
 	implementations.md \
 	bundle.md \

--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@
 Table of Contents
 
 - [Container Principles](principles.md)
+- [Specification Style](style.md)
 - [Filesystem Bundle](bundle.md)
 - Configuration
   - [Container Configuration](config.md)

--- a/style.md
+++ b/style.md
@@ -1,0 +1,21 @@
+# Style and conventions
+
+## Traditionally hex settings should use JSON integers, not JSON strings
+
+For example, [`"classID": 1048577`][class-id] instead of `"classID": "0x100001"`.
+The config JSON isn't enough of a UI to be worth jumping through string ↔ integer hoops to support an 0x… form ([source][integer-over-hex]).
+
+## Constant names should keep redundant prefixes
+
+For example, `CAP_KILL` instead of `KILL` in [**`linux.capabilities`**][capabilities]).
+The redundancy reduction from removing the namespacing prefix is not useful enough to be worth trimming the upstream identifier ([source][keep-prefix]).
+
+## Optional settings should have pointer Go types
+
+So we have a consistent way to identify unset values ([source][optional-pointer]).
+
+[capabilities]: config-linux.md#capabilities
+[class-id]: runtime-config-linux.md#network
+[integer-over-hex]: https://github.com/opencontainers/specs/pull/267#discussion_r48360013
+[keep-prefix]: https://github.com/opencontainers/specs/pull/159#issuecomment-138728337
+[optional-pointer]: https://github.com/opencontainers/specs/pull/233#discussion_r47829711


### PR DESCRIPTION
So we have something to cite to avoid rehashing established decisions.
Provide some motivation and links to the backing discussion so folks
can re-open these if they have new information that wasn't covered in
the original decision.

Like the glossary (18734986, glossary: Provide a quick overview of
important terms, 2015-08-11, #107), I've used subsection titles for
each entry to get link anchors.

I'm fine dropping any of the decisions from this PR if they turn out
to be contentious, and will happily add any that I missed if folks
bring them to my attention here.

Mailing-list suggestion [here][1], and I'm interpreting the absence of
feedback there, plus a maintainer proposing the same thing in #273 as
enough of a consensus to transition this idea into a PR.  If there is
pushback on the idea of listing policy/style decisions at all, we
should probably close this PR and post the pushback reason in the
mailing-list thread for further discussion.

Fixes #273.

[1]: https://groups.google.com/a/opencontainers.org/forum/#!topic/dev/CbiDx1WpleI