### PR TITLE
Makefile: Add glossary to DOC_FILES

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,7 +12,8 @@ DOC_FILES := \
 	config.md \
 	config-linux.md \
 	runtime-config.md \
-	runtime-config-linux.md
+	runtime-config-linux.md \
+	glossary.md
 
 docs: pdf html
 


### PR DESCRIPTION
At the end of the list, to match its position in the README.  This
catches #107 up with #263, which I'd missed during one of the #107
rebases.

Signed-off-by: W. Trevor King <wking@tremily.us>