### PR TITLE
MAINTAINERS: correct Vish's github account

### DIFF
--- a/MAINTAINERS
+++ b/MAINTAINERS
@@ -1,6 +1,6 @@
 Michael Crosby <michael@docker.com> (@crosbymichael)
 Alexander Morozov <lk4d4@docker.com> (@LK4D4)
-Vishnu Kannan <vishnuk@google.com> (@vishnuk)
+Vishnu Kannan <vishnuk@google.com> (@vishh)
 Mrunal Patel <mpatel@redhat.com> (@mrunalp)
 Vincent Batts <vbatts@redhat.com> (@vbatts)
 Daniel, Dao Quang Minh <dqminh89@gmail.com> (@dqminh)


### PR DESCRIPTION
https://github.com/opencontainers/specs/pull/223#discussion-diff-48630276

Reported-by: W. Trevor King <wking@tremily.us>
Signed-off-by: Vincent Batts <vbatts@hashbangbash.com>