### PR TITLE
Add NoNewPrivileges setting for linux

### DIFF
--- a/runtime-config-linux.md
+++ b/runtime-config-linux.md
@@ -503,3 +503,14 @@ Its value is either slave, private, or shared.
 ```json
     "rootfsPropagation": "slave",
 ```
+
+## No new privileges
+
+Setting `noNewPrivileges` to true prevents the processes in the container from gaining additional privileges.
+[The kernel doc](https://www.kernel.org/doc/Documentation/prctl/no_new_privs.txt) has more information on how this is achieved using a prctl system call.
+
+###### Example
+
+```json
+    "noNewPrivileges": true,
+```

--- a/runtime_config_linux.go
+++ b/runtime_config_linux.go
@@ -39,8 +39,10 @@ type LinuxRuntime struct {
 	SelinuxProcessLabel string `json:"selinuxProcessLabel"`
 	// Seccomp specifies the seccomp security settings for the container.
 	Seccomp Seccomp `json:"seccomp"`
-	// RootfsPropagation is the rootfs mount propagation mode for the container
+	// RootfsPropagation is the rootfs mount propagation mode for the container.
 	RootfsPropagation string `json:"rootfsPropagation,omitempty"`
+	// NoNewPrivileges controls whether additional privileges could be gained by processes in the container.
+	NoNewPrivileges bool `json:"noNewPrivileges,omitempty"`
 }
 
 // Namespace is the configuration for a linux namespace


### PR DESCRIPTION
This is a security setting that could be used to prevent processes in the
container from gaining additional privileges.

Signed-off-by: Mrunal Patel <mrunalp@gmail.com>