### PR TITLE
Makefile: add a target to run tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -15,6 +15,7 @@ DOC_FILES := \
 	runtime-config.md \
 	runtime-config-linux.md \
 	glossary.md
+EPOCH_TEST_COMMIT := 041eb73d2e0391463894c04c8ac938036143eba3
 
 docs: pdf html
 .PHONY: docs
@@ -43,7 +44,7 @@ html:
 
 .PHONY: test .govet .golint .gitvalidation
 
-test: .govet .golint
+test: .govet .golint .gitvalidation
 
 # `go get golang.org/x/tools/cmd/vet`
 .govet:
@@ -55,7 +56,7 @@ test: .govet .golint
 
 # `go get github.com/vbatts/git-validation`
 .gitvalidation:
-	git-validation -run DCO,short-subject -v -range ${TRAVIS_COMMIT_RANGE}
+	git-validation -q -run DCO,short-subject -v -range $(EPOCH_TEST_COMMIT)..HEAD
 
 clean:
 	rm -rf output/ *~

--- a/Makefile
+++ b/Makefile
@@ -17,6 +17,7 @@ DOC_FILES := \
 	glossary.md
 
 docs: pdf html
+.PHONY: docs
 
 pdf:
 	@mkdir -p output/ && \
@@ -39,6 +40,22 @@ html:
 	-u $(shell id -u) \
 	vbatts/pandoc -f markdown_github -t html5 -o /output/docs.html $(patsubst %,/input/%,$(DOC_FILES)) && \
 	ls -sh $(shell readlink -f output/docs.html)
+
+.PHONY: test .govet .golint .gitvalidation
+
+test: .govet .golint
+
+# `go get golang.org/x/tools/cmd/vet`
+.govet:
+	go vet -x ./...
+
+# `go get github.com/golang/lint/golint`
+.golint:
+	golint ./...
+
+# `go get github.com/vbatts/git-validation`
+.gitvalidation:
+	git-validation -run DCO,short-subject -v -range ${TRAVIS_COMMIT_RANGE}
 
 clean:
 	rm -rf output/ *~


### PR DESCRIPTION
For now, just vet and lint. But would like to include the commit
validator, once a good range is selectable.

Signed-off-by: Vincent Batts <vbatts@hashbangbash.com>