### PR TITLE
runtime-config-linux: Convert classID from hex to uint32

### DIFF
--- a/runtime-config-linux.md
+++ b/runtime-config-linux.md
@@ -378,7 +378,7 @@ For more information, see [the net\_cls cgroup man page](https://www.kernel.org/
 
 The following parameters can be specified to setup these cgroup controllers:
 
-* **`classID`** *(string, optional)* - is the network class identifier the cgroup's network packets will be tagged with
+* **`classID`** *(uint32, optional)* - is the network class identifier the cgroup's network packets will be tagged with
 
 * **`priorities`** *(array, optional)* - specifies a list of objects of the priorities assigned to traffic originating from
 processes in the group and egressing the system on various interfaces. The following parameters can be specified per-priority:
@@ -389,7 +389,7 @@ processes in the group and egressing the system on various interfaces. The follo
 
 ```json
    "network": {
-        "classID": "0x100001",
+        "classID": 1048577,
         "priorities": [
             {
                 "name": "eth0",

--- a/runtime_config_linux.go
+++ b/runtime_config_linux.go
@@ -191,9 +191,7 @@ type Pids struct {
 // Network identification and priority configuration
 type Network struct {
 	// Set class identifier for container's network packets
-	// this is actually a string instead of a uint64 to overcome the json
-	// limitation of specifying hex numbers
-	ClassID string `json:"classID"`
+	ClassID *uint32 `json:"classID"`
 	// Set priority of network traffic for container
 	Priorities []InterfacePriority `json:"priorities"`
 }


### PR DESCRIPTION
The just-landed style conventions (#287) prefer integers to hex
strings, and [I said I'd post an update for this setting if/when those
landed][2].  The kernel [uses uint32s for this setting][3].

[2]: https://github.com/opencontainers/specs/pull/287#discussion_r48899312
[3]: https://git.kernel.org/cgit/linux/kernel/git/torvalds/linux.git/tree/include/net/cls_cgroup.h?id=refs/tags/v4.3#n24