### PR TITLE
runtime-config-linux: Separate mknod from cgroups

### DIFF
--- a/config_linux.go
+++ b/config_linux.go
@@ -33,7 +33,7 @@ type Linux struct {
 	CgroupsPath *string `json:"cgroupsPath,omitempty"`
 	// Namespaces contains the namespaces that are created and/or joined by the container
 	Namespaces []Namespace `json:"namespaces"`
-	// Devices are a list of device nodes that are created and enabled for the container
+	// Devices are a list of device nodes that are created for the container
 	Devices []Device `json:"devices"`
 	// ApparmorProfile specified the apparmor profile for the container.
 	ApparmorProfile string `json:"apparmorProfile"`
@@ -213,6 +213,8 @@ type Network struct {
 
 // Resources has container runtime resource constraints
 type Resources struct {
+	// Devices are a list of device rules for the whitelist controller
+	Devices []DeviceCgroup `json:"devices"`
 	// DisableOOMKiller disables the OOM killer for out of memory conditions
 	DisableOOMKiller *bool `json:"disableOOMKiller,omitempty"`
 	// Specify an oom_score_adj for the container.
@@ -231,7 +233,7 @@ type Resources struct {
 	Network *Network `json:"network,omitempty"`
 }
 
-// Device represents the information on a Linux special device file
+// Device represents the mknod information for a Linux special device file
 type Device struct {
 	// Path to the device.
 	Path string `json:"path"`
@@ -241,14 +243,26 @@ type Device struct {
 	Major int64 `json:"major"`
 	// Minor is the device's minor number.
 	Minor int64 `json:"minor"`
-	// Cgroup permissions format, rwm.
-	Permissions string `json:"permissions"`
 	// FileMode permission bits for the device.
-	FileMode os.FileMode `json:"fileMode"`
+	FileMode *os.FileMode `json:"fileMode,omitempty"`
 	// UID of the device.
-	UID uint32 `json:"uid"`
+	UID *uint32 `json:"uid,omitempty"`
 	// Gid of the device.
-	GID uint32 `json:"gid"`
+	GID *uint32 `json:"gid,omitempty"`
+}
+
+// DeviceCgroup represents a device rule for the whitelist controller
+type DeviceCgroup struct {
+	// Allow or deny
+	Allow bool `json:"allow"`
+	// Device type, block, char, etc.
+	Type *rune `json:"type,omitempty"`
+	// Major is the device's major number.
+	Major *int64 `json:"major,omitempty"`
+	// Minor is the device's minor number.
+	Minor *int64 `json:"minor,omitempty"`
+	// Cgroup access permissions format, rwm.
+	Access *string `json:"access,omitempty"`
 }
 
 // Seccomp represents syscall restrictions


### PR DESCRIPTION
This is #99 rebased onto the current master, because [the idea seems
to have new life][0].  It leaves mknod entries in **`linux.devices`**
and moves cgroups entries into **`linux.resources.devices`**.  Quiet
thread on the issue [here][1].

This makes it easy to distinguish between configs that call for cgroup
adjustments (which have linux.resources entries) from those that
don't.  Without this split, folks interested in making that
distinction would have to parse the device section to determine if it
included cgroup changes.  This will also make it easy to drop either
portion ([mknod][2] or [cgroups][3]) independently of the other if the
project decides to do so.

Using seperate sections for mknod and cgroups also allows us to avoid
the complicated validation rules needed for the combined format
mknod/cgroup (#101).

Now that there is a section specific to supplying devices, I [shifted
the default device listing over from config-linux][5].  The `/dev/ptmx`
entry is a bit awkward, since it's not a device, but it seemed to fit
better over here.  But I would also be fine leaving it with the other
mounts in config-linux.

The reference links are sorted into two blocks, with kernel-doc links
sorted alphabetically followed by man pages sorted alphabetically by
section.

[0]: http://ircbot.wl.linuxfoundation.org/meetings/opencontainers/2016/opencontainers.2016-01-06-18.03.log.html#l-36
[1]: https://groups.google.com/a/opencontainers.org/forum/#!topic/dev/y_Fsa2_jJaM
[2]: https://github.com/opencontainers/specs/pull/98
[3]: https://groups.google.com/a/opencontainers.org/forum/#!topic/dev/qWHoKs8Fsrk
[5]: https://github.com/opencontainers/specs/pull/171#discussion_r41190655