### PR TITLE
state: remove the file API path

### DIFF
--- a/config_linux.go
+++ b/config_linux.go
@@ -2,9 +2,6 @@ package specs
 
 import "os"
 
-// LinuxStateDirectory holds the container's state information
-const LinuxStateDirectory = "/run/opencontainer/containers"
-
 // LinuxSpec is the full specification for linux containers.
 type LinuxSpec struct {
 	Spec

--- a/state.go
+++ b/state.go
@@ -1,9 +1,8 @@
 package specs
 
 // State holds information about the runtime state of the container.
-// This information will be stored in a file called `state.json`.
-// The location of this file will be operating system specific. On Linux
-// it will be in `/run/opencontainers/runc/<containerID>/state.json`
+// This information will be the struct of a `state` response from a runtime
+// regarding a created container.
 type State struct {
 	// Version is the version of the specification that is supported.
 	Version string `json:"version"`


### PR DESCRIPTION
After much discussion, we are not going to accommodate a compatible file
API, but rather have a response expected from a runtime to query for a
container's state.

This should like include the addition of paths to where the namespace references are bind mounted, at least for the linux platform