### PR TITLE
Minimum bar - compile on Windows (containerd dependency)

### DIFF
--- a/config_windows.go
+++ b/config_windows.go
@@ -1,0 +1,6 @@
+package specs
+
+// User specifies Windows specific information for the container's
+// main process.
+type User struct {
+}


### PR DESCRIPTION
Signed-off-by: John Howard <jhoward@microsoft.com>

@icecrime - Minimum bar to even start looking at containerd. Containerd pulls in opencontainer\specs which does not compile on Windows. This needs merging here and vendoring into containerd to make any chance of starting forward progress.