### PR TITLE
Move process specific settings to process

### DIFF
--- a/config-linux.md
+++ b/config-linux.md
@@ -3,19 +3,6 @@
 The Linux container specification uses various kernel features like namespaces, cgroups, capabilities, LSM, and file system jails to fulfill the spec.
 Additional information is needed for Linux over the [default spec configuration](config.md) in order to configure these various kernel features.
 
-## Capabilities
-
-Capabilities is an array that specifies Linux capabilities that can be provided to the process inside the container.
-Valid values are the strings for capabilities defined in [the man page](http://man7.org/linux/man-pages/man7/capabilities.7.html)
-
-```json
-   "capabilities": [
-        "CAP_AUDIT_WRITE",
-        "CAP_KILL",
-        "CAP_NET_BIND_SERVICE"
-    ]
-```
-
 ## Default File Systems
 
 The Linux ABI includes both syscalls and several special file paths.
@@ -486,28 +473,6 @@ The kernel enforces the `soft` limit for a resource while the `hard` limit acts 
    ]
 ```
 
-## SELinux process label
-
-SELinux process label specifies the label with which the processes in a container are run.
-For more information about SELinux, see  [Selinux documentation](http://selinuxproject.org/page/Main_Page)
-
-###### Example
-
-```json
-   "selinuxProcessLabel": "system_u:system_r:svirt_lxc_net_t:s0:c124,c675"
-```
-
-## Apparmor profile
-
-Apparmor profile specifies the name of the apparmor profile that will be used for the container.
-For more information about Apparmor, see [Apparmor documentation](https://wiki.ubuntu.com/AppArmor)
-
-###### Example
-
-```json
-   "apparmorProfile": "acme_secure_profile"
-```
-
 ## seccomp
 
 Seccomp provides application sandboxing mechanism in the Linux kernel.
@@ -572,17 +537,6 @@ Its value is either slave, private, or shared.
 
 ```json
     "rootfsPropagation": "slave",
-```
-
-## No new privileges
-
-Setting `noNewPrivileges` to true prevents the processes in the container from gaining additional privileges.
-[The kernel doc](https://www.kernel.org/doc/Documentation/prctl/no_new_privs.txt) has more information on how this is achieved using a prctl system call.
-
-###### Example
-
-```json
-    "noNewPrivileges": true,
 ```
 
 [cgroup-v1]: https://www.kernel.org/doc/Documentation/cgroup-v1/cgroups.txt

--- a/config.go
+++ b/config.go
@@ -33,6 +33,14 @@ type Process struct {
 	// Cwd is the current working directory for the process and must be
 	// relative to the container's root.
 	Cwd string `json:"cwd"`
+	// Capabilities are linux capabilities that are kept for the container.
+	Capabilities []string `json:"capabilities,omitempty"`
+	// ApparmorProfile specified the apparmor profile for the container.
+	ApparmorProfile string `json:"apparmorProfile,omitempty"`
+	// SelinuxProcessLabel specifies the selinux context that the container process is run as.
+	SelinuxLabel string `json:"selinuxLabel,omitempty"`
+	// NoNewPrivileges controls whether additional privileges could be gained by processes in the container.
+	NoNewPrivileges bool `json:"noNewPrivileges,omitempty"`
 }
 
 // Root contains information about the container's root filesystem on the host.

--- a/config.md
+++ b/config.md
@@ -90,6 +90,17 @@ See links for details about [mountvol](http://ss64.com/nt/mountvol.html) and [Se
 * **`env`** (array of strings, optional) contains a list of variables that will be set in the process's environment prior to execution. Elements in the array are specified as Strings in the form "KEY=value". The left hand side must consist solely of letters, digits, and underscores `_` as outlined in [IEEE Std 1003.1-2001](http://pubs.opengroup.org/onlinepubs/009695399/basedefs/xbd_chap08.html).
 * **`args`** (string, required) executable to launch and any flags as an array. The executable is the first element and must be available at the given path inside of the rootfs. If the executable path is not an absolute path then the search $PATH is interpreted to find the executable.
 
+For Linux-based systemd the process structure supports the following process specific fields:
+
+* **`capabilities`** (array of strings, optional) capabilities is an array that specifies Linux capabilities that can be provided to the process inside the container.
+Valid values are the strings for capabilities defined in [the man page](http://man7.org/linux/man-pages/man7/capabilities.7.html)
+* **`apparmorProfile`** (string, optional) apparmor profile specifies the name of the apparmor profile that will be used for the container.
+For more information about Apparmor, see [Apparmor documentation](https://wiki.ubuntu.com/AppArmor)
+* **`selinuxLabel`** (string, optional) SELinux process label specifies the label with which the processes in a container are run.
+For more information about SELinux, see  [Selinux documentation](http://selinuxproject.org/page/Main_Page)
+* **`noNewPrivileges`** (bool, optional) setting `noNewPrivileges` to true prevents the processes in the container from gaining additional privileges.
+[The kernel doc](https://www.kernel.org/doc/Documentation/prctl/no_new_privs.txt) has more information on how this is achieved using a prctl system call.
+
 The user for the process is a platform-specific structure that allows specific control over which user the process runs as.
 For Linux-based systems the user structure has the following fields:
 
@@ -114,6 +125,14 @@ For Linux-based systems the user structure has the following fields:
     "cwd": "/root",
     "args": [
         "sh"
+    ],
+   "apparmorProfile": "acme_secure_profile",
+   "selinuxLabel": "system_u:system_r:svirt_lxc_net_t:s0:c124,c675",
+    "noNewPrivileges": true,
+    "capabilities": [
+        "CAP_AUDIT_WRITE",
+        "CAP_KILL",
+        "CAP_NET_BIND_SERVICE"
     ]
 }
 ```

--- a/config_linux.go
+++ b/config_linux.go
@@ -14,8 +14,6 @@ type LinuxSpec struct {
 
 // Linux contains platform specific configuration for linux based containers.
 type Linux struct {
-	// Capabilities are linux capabilities that are kept for the container.
-	Capabilities []string `json:"capabilities"`
 	// UIDMapping specifies user mappings for supporting user namespaces on linux.
 	UIDMappings []IDMapping `json:"uidMappings,omitempty"`
 	// GIDMapping specifies group mappings for supporting user namespaces on linux.
@@ -35,16 +33,10 @@ type Linux struct {
 	Namespaces []Namespace `json:"namespaces"`
 	// Devices are a list of device nodes that are created for the container
 	Devices []Device `json:"devices"`
-	// ApparmorProfile specified the apparmor profile for the container.
-	ApparmorProfile string `json:"apparmorProfile"`
-	// SelinuxProcessLabel specifies the selinux context that the container process is run as.
-	SelinuxProcessLabel string `json:"selinuxProcessLabel"`
 	// Seccomp specifies the seccomp security settings for the container.
 	Seccomp Seccomp `json:"seccomp"`
 	// RootfsPropagation is the rootfs mount propagation mode for the container.
 	RootfsPropagation string `json:"rootfsPropagation,omitempty"`
-	// NoNewPrivileges controls whether additional privileges could be gained by processes in the container.
-	NoNewPrivileges bool `json:"noNewPrivileges,omitempty"`
 }
 
 // User specifies linux specific user and group information for the container's


### PR DESCRIPTION
This moves process specific settings like caps, apparmor, and selinux
process label onto the process structure to allow the same settings to
be changed at exec time.

Signed-off-by: Michael Crosby <crosbymichael@gmail.com>