### PR TITLE
specs-go/config: Fix 'SelinuxProcessLabel' -> 'SelinuxLabel'

### DIFF
--- a/specs-go/config.go
+++ b/specs-go/config.go
@@ -39,7 +39,7 @@ type Process struct {
 	Capabilities []string `json:"capabilities,omitempty"`
 	// ApparmorProfile specified the apparmor profile for the container.
 	ApparmorProfile string `json:"apparmorProfile,omitempty"`
-	// SelinuxProcessLabel specifies the selinux context that the container process is run as.
+	// SelinuxLabel specifies the selinux context that the container process is run as.
 	SelinuxLabel string `json:"selinuxLabel,omitempty"`
 	// NoNewPrivileges controls whether additional privileges could be gained by processes in the container.
 	NoNewPrivileges bool `json:"noNewPrivileges,omitempty"`


### PR DESCRIPTION
The label changed in 5a8a779f (Move process specific settings to
process, 2016-03-02, #329) and 7bf06d53 (source and schema:
differentiate with examples, 2015-12-18, #276) missed this instance
when rebasing around #329.