### PR TITLE
add omitempty to 'Devices

### DIFF
--- a/config.md
+++ b/config.md
@@ -404,12 +404,7 @@ Here is a full example `config.json` for reference.
             {
                 "type": "mount"
             }
-        ],
-        "devices": null,
-        "seccomp": {
-            "defaultAction": "",
-            "architectures": null
-        }
+        ]
     }
 }
 ```

--- a/specs-go/config.go
+++ b/specs-go/config.go
@@ -128,9 +128,9 @@ type Linux struct {
 	// If resources are specified, the cgroups at CgroupsPath will be updated based on resources.
 	CgroupsPath *string `json:"cgroupsPath,omitempty"`
 	// Namespaces contains the namespaces that are created and/or joined by the container
-	Namespaces []Namespace `json:"namespaces"`
+	Namespaces []Namespace `json:"namespaces,omitempty"`
 	// Devices are a list of device nodes that are created for the container
-	Devices []Device `json:"devices"`
+	Devices []Device `json:"devices,omitempty"`
 	// Seccomp specifies the seccomp security settings for the container.
 	Seccomp *Seccomp `json:"seccomp,omitempty"`
 	// RootfsPropagation is the rootfs mount propagation mode for the container.


### PR DESCRIPTION
1. Add 'omitempty' to 'Device'.
2. remove the 'seccomp' and 'device' from the example since they are not necessary
3. change the device type description `c` to "c" since it became a string.

Signed-off-by: liangchenye <liangchenye@huawei.com>