### PR TITLE
Move rlimits to process

### DIFF
--- a/config-linux.md
+++ b/config-linux.md
@@ -455,24 +455,6 @@ For more information, see [the man page](http://man7.org/linux/man-pages/man8/sy
    }
 ```
 
-## Rlimits
-
-rlimits allow setting resource limits.
-`type` is a string with a value from those defined in [the man page](http://man7.org/linux/man-pages/man2/setrlimit.2.html).
-The kernel enforces the `soft` limit for a resource while the `hard` limit acts as a ceiling for that value that could be set by an unprivileged process.
-
-###### Example
-
-```json
-   "rlimits": [
-        {
-            "type": "RLIMIT_NPROC",
-            "soft": 1024,
-            "hard": 102400
-        }
-   ]
-```
-
 ## seccomp
 
 Seccomp provides application sandboxing mechanism in the Linux kernel.

--- a/config.md
+++ b/config.md
@@ -90,7 +90,7 @@ See links for details about [mountvol](http://ss64.com/nt/mountvol.html) and [Se
 * **`env`** (array of strings, optional) contains a list of variables that will be set in the process's environment prior to execution. Elements in the array are specified as Strings in the form "KEY=value". The left hand side must consist solely of letters, digits, and underscores `_` as outlined in [IEEE Std 1003.1-2001](http://pubs.opengroup.org/onlinepubs/009695399/basedefs/xbd_chap08.html).
 * **`args`** (string, required) executable to launch and any flags as an array. The executable is the first element and must be available at the given path inside of the rootfs. If the executable path is not an absolute path then the search $PATH is interpreted to find the executable.
 
-For Linux-based systemd the process structure supports the following process specific fields:
+For Linux-based systems the process structure supports the following process specific fields:
 
 * **`capabilities`** (array of strings, optional) capabilities is an array that specifies Linux capabilities that can be provided to the process inside the container.
 Valid values are the strings for capabilities defined in [the man page](http://man7.org/linux/man-pages/man7/capabilities.7.html)

--- a/config.md
+++ b/config.md
@@ -94,6 +94,9 @@ For Linux-based systems the process structure supports the following process spe
 
 * **`capabilities`** (array of strings, optional) capabilities is an array that specifies Linux capabilities that can be provided to the process inside the container.
 Valid values are the strings for capabilities defined in [the man page](http://man7.org/linux/man-pages/man7/capabilities.7.html)
+* **`rlimits`** (array of rlimits, optional) rlimits is an array of rlimits that allows setting resource limits for a process inside the container.
+The kernel enforces the `soft` limit for a resource while the `hard` limit acts as a ceiling for that value that could be set by an unprivileged process.
+Valid values for the 'type' field are the resources defined in [the man page](http://man7.org/linux/man-pages/man2/setrlimit.2.html).
 * **`apparmorProfile`** (string, optional) apparmor profile specifies the name of the apparmor profile that will be used for the container.
 For more information about Apparmor, see [Apparmor documentation](https://wiki.ubuntu.com/AppArmor)
 * **`selinuxLabel`** (string, optional) SELinux process label specifies the label with which the processes in a container are run.
@@ -133,6 +136,13 @@ For Linux-based systems the user structure has the following fields:
         "CAP_AUDIT_WRITE",
         "CAP_KILL",
         "CAP_NET_BIND_SERVICE"
+    ],
+    "rlimits": [
+        {
+            "type": "RLIMIT_NOFILE",
+            "hard": 1024,
+            "soft": 1024
+        }
     ]
 }
 ```
@@ -278,6 +288,13 @@ Here is a full example `config.json` for reference.
             "CAP_KILL",
             "CAP_NET_BIND_SERVICE"
         ],
+        "rlimits": [
+            {
+                "type": "RLIMIT_NOFILE",
+                "hard": 1024,
+                "soft": 1024
+            }
+        ],
         "apparmorProfile": "",
         "selinuxLabel": ""
     },
@@ -373,13 +390,6 @@ Here is a full example `config.json` for reference.
         ]
     },
     "linux": {
-        "rlimits": [
-            {
-                "type": "RLIMIT_NOFILE",
-                "hard": 1024,
-                "soft": 1024
-            }
-        ],
         "resources": {
             "devices": [
                 {

--- a/specs-go/config.go
+++ b/specs-go/config.go
@@ -42,6 +42,8 @@ type Process struct {
 	Cwd string `json:"cwd"`
 	// Capabilities are Linux capabilities that are kept for the container.
 	Capabilities []string `json:"capabilities,omitempty" platform:"linux"`
+	// Rlimits specifies rlimit options to apply to the process.
+	Rlimits []Rlimit `json:"rlimits,omitempty"`
 	// NoNewPrivileges controls whether additional privileges could be gained by processes in the container.
 	NoNewPrivileges bool `json:"noNewPrivileges,omitempty"`
 
@@ -116,8 +118,6 @@ type Linux struct {
 	UIDMappings []IDMapping `json:"uidMappings,omitempty"`
 	// GIDMapping specifies group mappings for supporting user namespaces on Linux.
 	GIDMappings []IDMapping `json:"gidMappings,omitempty"`
-	// Rlimits specifies rlimit options to apply to the container's process.
-	Rlimits []Rlimit `json:"rlimits,omitempty"`
 	// Sysctl are a set of key value pairs that are set for the container on start
 	Sysctl map[string]string `json:"sysctl,omitempty"`
 	// Resources contain cgroup information for handling resource constraints


### PR DESCRIPTION
As discussed at the 9/3/16 weekly call and on IRC, this moves the rlimits struct on to process to match capabilities, apparmor, selinux etc which were moved in 5a8a779.

Also fixed a typo (`systemd` -> `systems`)