### PR TITLE
config: Make Markdown canonical

### DIFF
--- a/config.md
+++ b/config.md
@@ -1,7 +1,7 @@
 # Container Configuration file
 
 The container's top-level directory MUST contain a configuration file called `config.json`.
-For now the canonical schema is defined in [config.go](config.go) and [config_linux.go](config_linux.go), but this will be moved to a formal JSON schema over time.
+The canonical schema is defined in this document, but there is a JSON Schema in [`schema/schema.json`](schema/schema.json) and Go bindings in [`specs-go/config.go`](specs-go/config.go).
 
 The configuration file contains metadata necessary to implement standard operations against the container.
 This includes the process to run, environment variables to inject, sandboxing features to use, etc.

--- a/project.md
+++ b/project.md
@@ -2,7 +2,7 @@
 
 ## Release Process
 
-* Increment version in version.go
+* Increment version in [`specs-go/version.go`](specs-go/version.go)
 * `git commit` version increment
 * `git tag` the prior commit (preferrably signed tag)
 * `make docs` to produce PDF and HTML copies of the spec


### PR DESCRIPTION
It's pretty clear that the Go bindings cannot be canonical on their
own, because they do not define limits (e.g. the 0 through 512 range
for `FileMode`).  The JSON Schema is closer, but still does not cover
everything (e.g. “a directory must exist at **`root.path`**”).  Both
the Go bindings and the JSON Schema could grow to cover the full spec
by adding that sort of thing to comments and descriptions, but that's
not how things seem to be working now.

Also:

* Update links to Go bindings after 7bf06d5 (source and schema:
  differentiate with examples, 2015-12-18, #276).
* Add a reference to the JSON Schema after cdcabde (schema: JSON
  Schema and validator for `config.json`, 2016-01-19, #313).