### PR TITLE
Add timeout field to hooks

### DIFF
--- a/config.md
+++ b/config.md
@@ -226,6 +226,7 @@ If a hook returns a non-zero exit code, then an error is logged and the remainin
         "poststart": [
             {
                 "path": "/usr/bin/notify-start"
+                "timeout": 5
             }
         ],
         "poststop": [
@@ -239,6 +240,7 @@ If a hook returns a non-zero exit code, then an error is logged and the remainin
 
 `path` is required for a hook.
 `args` and `env` are optional.
+`timeout` is the number of seconds before aborting the hook.
 The semantics are the same as `Path`, `Args` and `Env` in [golang Cmd](https://golang.org/pkg/os/exec/#Cmd).
 
 ## Annotations

--- a/specs-go/config.go
+++ b/specs-go/config.go
@@ -96,9 +96,10 @@ type Mount struct {
 
 // Hook specifies a command that is run at a particular event in the lifecycle of a container
 type Hook struct {
-	Path string   `json:"path"`
-	Args []string `json:"args,omitempty"`
-	Env  []string `json:"env,omitempty"`
+	Path    string   `json:"path"`
+	Args    []string `json:"args,omitempty"`
+	Env     []string `json:"env,omitempty"`
+	Timeout *int     `json:"timeout,omitempty"`
 }
 
 // Hooks for container setup and teardown


### PR DESCRIPTION
So that runtimes don't lock up forever waiting on a hook to return I
added a timeout field.  This allows the author to specify the timeout in
seconds that they want the hook to run before aborting the hook and
container execution.

I think the hook is the proper place to specify a timeouot like this
because any type of overall timeout in the runtime will probably not
work for all hooks and will not be flexable enough.

Let me know that you all think.  

Signed-off-by: Michael Crosby <crosbymichael@gmail.com>