### PR TITLE
fix go get path

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -56,7 +56,7 @@ test: .govet .golint .gitvalidation
 .gitvalidation:
 	git-validation -q -run DCO,short-subject -v -range $(EPOCH_TEST_COMMIT)..HEAD
 
-# `go get https://github.com/pquerna/ffjson`
+# `go get github.com/pquerna/ffjson`
 ffjson:
 	cd specs-go/ && ffjson config.go
 	cd specs-go/ && ffjson state.go


### PR DESCRIPTION
go get https://github.com/pquerna/ffjson
package https:/github.com/pquerna/ffjson: "https://" not allowed in
import path

so we remove the "https://"

Signed-off-by: Lai Jiangshan <jiangshanlai@gmail.com>